### PR TITLE
Allow to change name of the integration

### DIFF
--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -87,7 +87,6 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
         self.hass = hass
         self.config_entry = config_entry
         self.api_device_name = api_device_name
-        config_entry.title = api_device_name
         self.query_obj = {OBJ: {}}
         self.load_all_sensor_data()
 
@@ -167,5 +166,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    hass.data[DOMAIN][entry.entry_id].config_entry = entry
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import MoonrakerApiClient
-from .const import CONF_PORT, CONF_URL, DOMAIN, HOSTNAME, OBJ, PLATFORMS
+from .const import CONF_PORT, CONF_URL, DOMAIN, OBJ, PLATFORMS
 from .sensor import SENSORS
 
 SCAN_INTERVAL = timedelta(seconds=30)

--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import MoonrakerApiClient
-from .const import CONF_PORT, CONF_URL, DOMAIN, OBJ, PLATFORMS
+from .const import CONF_PORT, CONF_URL, DOMAIN, HOSTNAME, OBJ, PLATFORMS
 from .sensor import SENSORS
 
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -47,7 +47,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         async with async_timeout.timeout(TIMEOUT):
             printer_info = await api.client.call_method("printer.info")
             _LOGGER.debug(printer_info)
-            api_device_name = entry.title
+            api_device_name = printer_info[HOSTNAME]
+            if entry.title == DOMAIN:
+                entry.title = api_device_name
     except Exception as exc:
         raise ConfigEntryNotReady from exc
 

--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -47,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         async with async_timeout.timeout(TIMEOUT):
             printer_info = await api.client.call_method("printer.info")
             _LOGGER.debug(printer_info)
-            api_device_name = printer_info[HOSTNAME]
+            api_device_name = entry.title
     except Exception as exc:
         raise ConfigEntryNotReady from exc
 

--- a/custom_components/moonraker/config_flow.py
+++ b/custom_components/moonraker/config_flow.py
@@ -18,7 +18,6 @@ class MoonrakerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize."""
         _LOGGER.debug("loading moonraker confFlowHandler")
         self._errors = {}
-        self.title = DOMAIN
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
@@ -33,7 +32,7 @@ class MoonrakerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self._errors[CONF_PORT] = "port_error"
                 return await self._show_config_form(user_input)
 
-            return self.async_create_entry(title=self.title, data=user_input)
+            return self.async_create_entry(title=DOMAIN, data=user_input)
 
         user_input = {}
         # Provide defaults for form

--- a/custom_components/moonraker/config_flow.py
+++ b/custom_components/moonraker/config_flow.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant import config_entries
 import voluptuous as vol
 
-from .const import CONF_PORT, CONF_URL, DOMAIN, INTEGRATION_NAME
+from .const import CONF_PORT, CONF_URL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ class MoonrakerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize."""
         _LOGGER.debug("loading moonraker confFlowHandler")
         self._errors = {}
-        self.title = None
+        self.title = DOMAIN
 
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
@@ -33,7 +33,7 @@ class MoonrakerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self._errors[CONF_PORT] = "port_error"
                 return await self._show_config_form(user_input)
 
-            return self.async_create_entry(title=INTEGRATION_NAME, data=user_input)
+            return self.async_create_entry(title=self.title, data=user_input)
 
         user_input = {}
         # Provide defaults for form
@@ -59,6 +59,10 @@ class MoonrakerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _test_connection(self, _url):
         """Return true if connection is valid."""
+        # Test connection and get hostname
+        # await api.client.call_method("printer.info")
+        # printer_info[HOSTNAME]
+        self.title = DOMAIN  # TODO change for hostname
         return True
 
     async def _test_port(self, port):

--- a/custom_components/moonraker/config_flow.py
+++ b/custom_components/moonraker/config_flow.py
@@ -4,7 +4,7 @@ import logging
 from homeassistant import config_entries
 import voluptuous as vol
 
-from .const import CONF_PORT, CONF_URL, DOMAIN
+from .const import CONF_PORT, CONF_URL, DOMAIN, INTEGRATION_NAME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,8 +33,7 @@ class MoonrakerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self._errors[CONF_PORT] = "port_error"
                 return await self._show_config_form(user_input)
 
-            # changer DOMAIN pour name
-            return self.async_create_entry(title=DOMAIN, data=user_input)
+            return self.async_create_entry(title=INTEGRATION_NAME, data=user_input)
 
         user_input = {}
         # Provide defaults for form

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -4,7 +4,6 @@ from homeassistant.const import Platform
 # Base component constants
 DOMAIN = "moonraker"
 DOMAIN_DATA = f"{DOMAIN}_data"
-INTEGRATION_NAME = "Moonraker"
 VERSION = "0.2.0"
 MANIFACTURER = "@marcolivierarsenault"
 

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -14,5 +14,5 @@ CONF_URL = "url"
 CONF_PORT = "port"
 
 # API dict keys
-
+HOSTNAME = "hostname"
 OBJ = "objects"

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -15,5 +15,4 @@ CONF_PORT = "port"
 
 # API dict keys
 
-HOSTNAME = "hostname"
 OBJ = "objects"

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -4,6 +4,7 @@ from homeassistant.const import Platform
 # Base component constants
 DOMAIN = "moonraker"
 DOMAIN_DATA = f"{DOMAIN}_data"
+INTEGRATION_NAME = "Moonraker"
 VERSION = "0.2.0"
 MANIFACTURER = "@marcolivierarsenault"
 

--- a/custom_components/moonraker/entity.py
+++ b/custom_components/moonraker/entity.py
@@ -19,6 +19,6 @@ class BaseMoonrakerEntity(CoordinatorEntity):
         return DeviceInfo(
             identifiers={(DOMAIN, self.config_entry.entry_id)},
             name=self.api_device_name,
-            model=self.api_device_name,
+            model=DOMAIN,
             manufacturer=DOMAIN,
         )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,7 +3,12 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
 
-from custom_components.moonraker.const import CONF_PORT, CONF_URL, DOMAIN
+from custom_components.moonraker.const import (
+    CONF_PORT,
+    CONF_URL,
+    DOMAIN,
+    INTEGRATION_NAME,
+)
 
 from .const import MOCK_CONFIG
 
@@ -28,7 +33,7 @@ async def test_successful_config_flow(hass):
     # Check that the config flow is complete and a new entry is created with
     # the input data
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "moonraker"
+    assert result["title"] == INTEGRATION_NAME
     assert result["data"] == MOCK_CONFIG
     assert result["result"]
 
@@ -101,7 +106,7 @@ async def test_server_port_when_good_port(hass):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "moonraker"
+    assert result["title"] == INTEGRATION_NAME
     assert result["data"] == {CONF_URL: "1.2.3.4", CONF_PORT: "7611"}
     assert result["result"]
 
@@ -117,6 +122,6 @@ async def test_server_port_when_port_empty(hass):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "moonraker"
+    assert result["title"] == INTEGRATION_NAME
     assert result["data"] == {CONF_URL: "1.2.3.4", CONF_PORT: ""}
     assert result["result"]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -102,7 +102,7 @@ async def test_server_port_when_good_port(hass):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == DOMAIN
-    assert result["data"] == {CONF_URL: "1.2.3.4", CONF_PORT: "7611"}
+    assert result["data"] == {CONF_URL: "1.2.3.4", CONF_PORT: "7611", CONF_API_KEY: ""}
     assert result["result"]
 
 
@@ -118,7 +118,8 @@ async def test_server_port_when_port_empty(hass):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == DOMAIN
-    assert result["data"] == {CONF_URL: "1.2.3.4", CONF_PORT: ""}
+    assert result["data"] == {CONF_URL: "1.2.3.4", CONF_PORT: "", CONF_API_KEY: ""}
+
 
 async def test_server_api_key_weird_char(hass):
     """Test api key when contains weird characters"""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,12 +3,7 @@ from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow
 
-from custom_components.moonraker.const import (
-    CONF_PORT,
-    CONF_URL,
-    DOMAIN,
-    INTEGRATION_NAME,
-)
+from custom_components.moonraker.const import CONF_PORT, CONF_URL, DOMAIN
 
 from .const import MOCK_CONFIG
 
@@ -33,7 +28,7 @@ async def test_successful_config_flow(hass):
     # Check that the config flow is complete and a new entry is created with
     # the input data
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == INTEGRATION_NAME
+    assert result["title"] == DOMAIN
     assert result["data"] == MOCK_CONFIG
     assert result["result"]
 
@@ -106,7 +101,7 @@ async def test_server_port_when_good_port(hass):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == INTEGRATION_NAME
+    assert result["title"] == DOMAIN
     assert result["data"] == {CONF_URL: "1.2.3.4", CONF_PORT: "7611"}
     assert result["result"]
 
@@ -122,6 +117,6 @@ async def test_server_port_when_port_empty(hass):
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == INTEGRATION_NAME
+    assert result["title"] == DOMAIN
     assert result["data"] == {CONF_URL: "1.2.3.4", CONF_PORT: ""}
     assert result["result"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -38,7 +38,8 @@ async def test_setup_unload_and_reload_entry(hass, get_data, get_printer_info):
             hass.data[DOMAIN][config_entry.entry_id], MoonrakerDataUpdateCoordinator
         )
 
-        # Reload the entry and assert that the data from above is still there
+        # Reload the entry and assert that the data from above is still there.
+        hass.config_entries._entries[config_entry.entry_id] = config_entry
         assert await async_reload_entry(hass, config_entry) is None
         assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
         assert isinstance(


### PR DESCRIPTION
The patch allow the user to change the title of the integration. It also remove the default name of the integration based on the hostname and use Moonraker instead.

The patch also rework the async_reload_entry method to reload the configuration instead of unloading and resetuping the integration.

#27 