### PR TITLE
add context to optional API Key

### DIFF
--- a/custom_components/moonraker/translations/en.json
+++ b/custom_components/moonraker/translations/en.json
@@ -6,7 +6,7 @@
                 "data": {
                     "url": "url",
                     "port": "port",
-                    "api_key": "api_key"
+                    "api_key": "api_key (Optional)"
                 }
             }
         },


### PR DESCRIPTION
Wanted to make it clear that API Key could stay empty
![image](https://user-images.githubusercontent.com/2634090/222993293-8d0839ac-b777-4170-b15f-aef25823cf4e.png)
