### PR TITLE
manage None port from pre 0.3.0

### DIFF
--- a/custom_components/moonraker/api.py
+++ b/custom_components/moonraker/api.py
@@ -16,6 +16,8 @@ class MoonrakerApiClient(MoonrakerListener):
         self.running = False
         if api_key == "":
             api_key = None
+        if port is None:
+            port = 7125
         self.client = MoonrakerClient(
             listener=self, host=url, port=port, session=session, api_key=api_key
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,3 +15,16 @@ async def test_connect_client():
         assert moonraker_api.running
         await moonraker_api.stop()
         assert not moonraker_api.running
+
+
+async def test_none_port_connect_client():
+    """Test connect client"""
+    with patch("moonraker_api.MoonrakerClient"), patch(
+        "moonraker_api.websockets.websocketclient.WebsocketClient.connect"
+    ), patch("moonraker_api.websockets.websocketclient.WebsocketClient.disconnect"):
+        moonraker_api = MoonrakerApiClient("notaURL", None, port=None, api_key="1dd2")
+        assert not moonraker_api.running
+        await moonraker_api.start()
+        assert moonraker_api.running
+        await moonraker_api.stop()
+        assert not moonraker_api.running


### PR DESCRIPTION
Make easier migration from pre 0.3.0

Add simple logic to move `None` to `7125`