### PR TITLE
Add Sensor for Display Message

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -55,6 +55,12 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("print_stats", "message")],
     ),
     MoonrakerSensorDescription(
+        key="display_message",
+        name="Current Display Message",
+        value_fn=lambda data: data["status"]["display_status"]["message"],
+        subscriptions=[("display_status", "message")],
+    ),
+    MoonrakerSensorDescription(
         key="extruder_temp",
         name="Extruder Temperature",
         value_fn=lambda data: float(data["status"]["extruder"]["temperature"]),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,10 @@ def get_data_fixture():
                 "target": 60.0,
                 "power": 0.26053745272533363,
             },
-            "display_status": {"progress": 0.9078104237663283, "message": None},
+            "display_status": {
+                "progress": 0.9078104237663283,
+                "message": "Custom Message",
+            },
         },
         "printer.info": {
             "result": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -61,6 +61,7 @@ async def test_sensor_services_update(hass, get_data, get_printer_info):
         ("mainsail_extruder_temperature", "205.02"),
         ("mainsail_progress", "90"),
         ("mainsail_printer_state", "ready"),
+        ("mainsail_current_display_message", "Custom Message"),
         ("mainsail_printer_message", "Printer is ready"),
         ("mainsail_current_print_state", "printing"),
         ("mainsail_current_print_message", ""),


### PR DESCRIPTION
Add sensor for display message, 
Proposition from issue #31 

![image](https://user-images.githubusercontent.com/2634090/223299874-c9c1934d-f82f-4d50-8104-8ba6eed0f0a6.png)


This implement [Display Message from klipper doc](https://www.klipper3d.org/G-Codes.html#display_status)

To send message from Klipper type 
`SET_DISPLAY_TEXT MSG=<message>`