### PR TITLE
add empty string on Null display message

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -57,7 +57,9 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="display_message",
         name="Current Display Message",
-        value_fn=lambda data: data["status"]["display_status"]["message"],
+        value_fn=lambda data: data["status"]["display_status"]["message"]
+        if data["status"]["display_status"]["message"] is not None
+        else "",
         subscriptions=[("display_status", "message")],
     ),
     MoonrakerSensorDescription(


### PR DESCRIPTION
To fix #43 

Now when their is no message we get an empty string instead of unknown (as shown in the issue)
![image](https://user-images.githubusercontent.com/2634090/224031144-076dd297-e4ff-4428-9c92-ed287c7ac49b.png)

