### PR TITLE
Add support for optional temperature sensors

### DIFF
--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -146,9 +146,19 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
         """Return list of cameras"""
         return await self._async_fetch_data("server.webcams.list", None)
 
+    async def async_get_printer_object_list(self):
+        """Return printer objects"""
+        return await self._async_fetch_data("printer.objects.list", None)
+
     def load_all_sensor_data(self):
         """pre loading all sensor data, so we can poll the right object"""
         for sensor in SENSORS:
+            for subscriptions in sensor.subscriptions:
+                self.add_query_objects(subscriptions[0], subscriptions[1])
+
+    def load_sensor_list(self, sensor_list):
+        """Load a sensor list"""
+        for sensor in sensor_list:
             for subscriptions in sensor.subscriptions:
                 self.add_query_objects(subscriptions[0], subscriptions[1])
 

--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -99,14 +99,14 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
         self.config_entry = config_entry
         self.api_device_name = api_device_name
         self.query_obj = {OBJ: {}}
-        self.load_all_sensor_data()
+        self.load_sensor_data(SENSORS)
 
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL)
 
     async def _async_update_data(self):
         """Update data via library."""
         query = await self._async_fetch_data(
-            METHOD.PRINTER_OBJECT_QUERY, self.query_obj
+            METHOD.PRINTER_OBJECTS_QUERY, self.query_obj
         )
         info = await self.async_fetch_data(METHOD.PRINTER_INFO)
         gcode_file_details = await self._async_get_gcode_file_detail(
@@ -157,14 +157,8 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from moonraker"""
         return await self._async_fetch_data(query_path, None)
 
-    def load_all_sensor_data(self):
-        """pre loading all sensor data, so we can poll the right object"""
-        for sensor in SENSORS:
-            for subscriptions in sensor.subscriptions:
-                self.add_query_objects(subscriptions[0], subscriptions[1])
-
-    def load_sensor_list(self, sensor_list):
-        """Load a sensor list"""
+    def load_sensor_data(self, sensor_list):
+        """Loading sensor data, so we can poll the right object"""
         for sensor in sensor_list:
             for subscriptions in sensor.subscriptions:
                 self.add_query_objects(subscriptions[0], subscriptions[1])

--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -19,9 +19,9 @@ from .const import (
     CONF_URL,
     DOMAIN,
     HOSTNAME,
+    METHOD,
     OBJ,
     PLATFORMS,
-    METHOD,
 )
 from .sensor import SENSORS
 

--- a/custom_components/moonraker/camera.py
+++ b/custom_components/moonraker/camera.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_URL, DOMAIN
+from .const import CONF_URL, DOMAIN, METHOD
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ async def async_setup_entry(
     """Set up the available Moonraker camera."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    cameras = await coordinator.async_get_cameras()
+    cameras = await coordinator.async_fetch_data(METHOD.SERVER_WEBCAMS_LIST)
 
     for camera_id, camera in enumerate(cameras["webcams"]):
         async_add_entities(

--- a/custom_components/moonraker/camera.py
+++ b/custom_components/moonraker/camera.py
@@ -1,4 +1,4 @@
-"""Support for OctoPrint binary camera."""
+"""Support for Moonraker camera."""
 from __future__ import annotations
 
 import logging

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -1,5 +1,6 @@
 """Constants for Moonraker."""
 from homeassistant.const import Platform
+from enum import Enum
 
 # Base component constants
 DOMAIN = "moonraker"
@@ -17,3 +18,17 @@ CONF_PORT = "port"
 # API dict keys
 HOSTNAME = "hostname"
 OBJ = "objects"
+
+
+class METHOD(Enum):
+    """API methods."""
+
+    SERVER_FILES_METADATA = "server.files.metadata"
+    SERVER_WEBCAMS_LIST = "server.webcams.list"
+    PRINTER_INFO = "printer.info"
+    PRINTER_OBJECTS_LIST = "printer.objects.list"
+    PRINTER_OBJECTS_QUERY = "printer.objects.query"
+
+    def __str__(self):
+        """Return the method name."""
+        return self.value

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -1,6 +1,7 @@
 """Constants for Moonraker."""
-from homeassistant.const import Platform
 from enum import Enum
+
+from homeassistant.const import Platform
 
 # Base component constants
 DOMAIN = "moonraker"

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -233,16 +233,20 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities([MoonrakerSensor(coordinator, entry, desc) for desc in SENSORS])
 
     object_list = await coordinator.async_fetch_data(METHOD.PRINTER_OBJECTS_LIST)
-    opt_sensors = await async_setup_optional_temp_sensors(object_list)
+    opt_sensors = await async_setup_optional_sensors(object_list)
+    if not opt_sensors:
+        return
+
+    coordinator.load_sensor_data(opt_sensors)
+
+    await coordinator.async_refresh()
 
     async_add_entities(
         [MoonrakerSensor(coordinator, entry, desc) for desc in opt_sensors]
     )
 
-    coordinator.load_sensor_list(opt_sensors)
 
-
-async def async_setup_optional_temp_sensors(object_list):
+async def async_setup_optional_sensors(object_list):
     """Setup optional sensor platform."""
     sensor_list = []
     for obj in object_list["objects"]:

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import DEGREE, LENGTH_METERS, PERCENTAGE, TIME_SECONDS
 from homeassistant.core import callback
 
-from .const import DOMAIN
+from .const import DOMAIN, METHOD
 from .entity import BaseMoonrakerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -226,7 +226,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     async_add_entities([MoonrakerSensor(coordinator, entry, desc) for desc in SENSORS])
 
-    object_list = await coordinator.async_get_printer_object_list()
+    object_list = await coordinator.async_fetch_data(METHOD.PRINTER_OBJECTS_LIST)
     opt_sensors = await async_setup_optional_temp_sensors(object_list)
 
     async_add_entities(

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -34,39 +34,43 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="state",
         name="Printer State",
-        value_fn=lambda data: data["printer.info"]["state"],
+        value_fn=lambda data: data.coordinator.data["printer.info"]["state"],
         subscriptions=[],
     ),
     MoonrakerSensorDescription(
         key="message",
         name="Printer Message",
-        value_fn=lambda data: data["printer.info"]["state_message"],
+        value_fn=lambda data: data.coordinator.data["printer.info"]["state_message"],
         subscriptions=[],
     ),
     MoonrakerSensorDescription(
         key="print_state",
         name="Current Print State",
-        value_fn=lambda data: data["status"]["print_stats"]["state"],
+        value_fn=lambda data: data.coordinator.data["status"]["print_stats"]["state"],
         subscriptions=[("print_stats", "state")],
     ),
     MoonrakerSensorDescription(
         key="print_message",
         name="Current Print Message",
-        value_fn=lambda data: data["status"]["print_stats"]["message"],
+        value_fn=lambda data: data.coordinator.data["status"]["print_stats"]["message"],
         subscriptions=[("print_stats", "message")],
     ),
     MoonrakerSensorDescription(
         key="display_message",
         name="Current Display Message",
-        value_fn=lambda data: data["status"]["display_status"]["message"]
-        if data["status"]["display_status"]["message"] is not None
+        value_fn=lambda data: data.coordinator.data["status"]["display_status"][
+            "message"
+        ]
+        if data.coordinator.data["status"]["display_status"]["message"] is not None
         else "",
         subscriptions=[("display_status", "message")],
     ),
     MoonrakerSensorDescription(
         key="extruder_temp",
         name="Extruder Temperature",
-        value_fn=lambda data: float(data["status"]["extruder"]["temperature"]),
+        value_fn=lambda data: float(
+            data.coordinator.data["status"]["extruder"]["temperature"]
+        ),
         subscriptions=[("extruder", "temperature")],
         icon="mdi:printer-3d-nozzle-heat",
         unit=DEGREE,
@@ -74,7 +78,9 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="extruder_target",
         name="Extruder Target",
-        value_fn=lambda data: float(data["status"]["extruder"]["target"]),
+        value_fn=lambda data: float(
+            data.coordinator.data["status"]["extruder"]["target"]
+        ),
         subscriptions=[("extruder", "target")],
         icon="mdi:printer-3d-nozzle-heat",
         unit=DEGREE,
@@ -82,7 +88,9 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="bed_target",
         name="Bed Target",
-        value_fn=lambda data: float(data["status"]["heater_bed"]["target"]),
+        value_fn=lambda data: float(
+            data.coordinator.data["status"]["heater_bed"]["target"]
+        ),
         subscriptions=[("heater_bed", "target")],
         icon="mdi:radiator",
         unit=DEGREE,
@@ -90,7 +98,9 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="bed_temp",
         name="Bed Temperature",
-        value_fn=lambda data: float(data["status"]["heater_bed"]["temperature"]),
+        value_fn=lambda data: float(
+            data.coordinator.data["status"]["heater_bed"]["temperature"]
+        ),
         subscriptions=[("heater_bed", "temperature")],
         icon="mdi:radiator",
         unit=DEGREE,
@@ -98,15 +108,18 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="filename",
         name="Filename",
-        value_fn=lambda data: data["status"]["print_stats"]["filename"],
+        value_fn=lambda data: data.coordinator.data["status"]["print_stats"][
+            "filename"
+        ],
         subscriptions=[("print_stats", "filename")],
     ),
     MoonrakerSensorDescription(
         key="print_projected_total_duration",
         name="print Projected Total Duration",
         value_fn=lambda data: round(
-            data["status"]["print_stats"]["print_duration"] / calculate_pct_job(data)
-            if calculate_pct_job(data) != 0
+            data.coordinator.data["status"]["print_stats"]["print_duration"]
+            / calculate_pct_job(data.coordinator.data)
+            if calculate_pct_job(data.coordinator.data) != 0
             else 0,
             2,
         ),
@@ -123,12 +136,12 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         name="Print Time Left",
         value_fn=lambda data: round(
             (
-                data["status"]["print_stats"]["print_duration"]
-                / calculate_pct_job(data)
-                if calculate_pct_job(data) != 0
+                data.coordinator.data["status"]["print_stats"]["print_duration"]
+                / calculate_pct_job(data.coordinator.data)
+                if calculate_pct_job(data.coordinator.data) != 0
                 else 0
             )
-            - data["status"]["print_stats"]["print_duration"],
+            - data.coordinator.data["status"]["print_stats"]["print_duration"],
             2,
         ),
         subscriptions=[
@@ -142,7 +155,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="print_eta",
         name="Print ETA",
-        value_fn=lambda data: calculate_eta(data),
+        value_fn=lambda data: calculate_eta(data.coordinator.data),
         subscriptions=[
             ("print_stats", "print_duration"),
             ("display_status", "progress"),
@@ -154,7 +167,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         key="print_duration",
         name="Print Duration",
         value_fn=lambda data: round(
-            data["status"]["print_stats"]["print_duration"] / 60, 2
+            data.coordinator.data["status"]["print_stats"]["print_duration"] / 60, 2
         ),
         subscriptions=[("print_stats", "print_duration")],
         icon="mdi:timer",
@@ -165,7 +178,10 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         key="filament_used",
         name="Filament Used",
         value_fn=lambda data: round(
-            int(data["status"]["print_stats"]["filament_used"]) * 1.0 / 1000, 2
+            int(data.coordinator.data["status"]["print_stats"]["filament_used"])
+            * 1.0
+            / 1000,
+            2,
         ),
         subscriptions=[("print_stats", "filament_used")],
         icon="mdi:tape-measure",
@@ -174,7 +190,9 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="progress",
         name="Progress",
-        value_fn=lambda data: int(data["status"]["display_status"]["progress"] * 100),
+        value_fn=lambda data: int(
+            data.coordinator.data["status"]["display_status"]["progress"] * 100
+        ),
         subscriptions=[("display_status", "progress")],
         icon="mdi:percent",
         unit=PERCENTAGE,
@@ -182,7 +200,9 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="bed_power",
         name="Bed Power",
-        value_fn=lambda data: int(data["status"]["heater_bed"]["power"] * 100),
+        value_fn=lambda data: int(
+            data.coordinator.data["status"]["heater_bed"]["power"] * 100
+        ),
         subscriptions=[("heater_bed", "power")],
         icon="mdi:flash",
         unit=PERCENTAGE,
@@ -190,7 +210,9 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="extruder_power",
         name="Extruder Power",
-        value_fn=lambda data: int(data["status"]["extruder"]["power"] * 100),
+        value_fn=lambda data: int(
+            data.coordinator.data["status"]["extruder"]["power"] * 100
+        ),
         subscriptions=[("extruder", "power")],
         icon="mdi:flash",
         unit=PERCENTAGE,
@@ -224,26 +246,15 @@ async def async_setup_optional_temp_sensors(object_list):
                 MoonrakerSensorDescription(
                     key=split_obj[1],
                     name=split_obj[1].replace("_", " ").title(),
-                    value_fn=MoonrakerOptionalTempSensor(obj),
+                    value_fn=lambda data: data.coordinator.data["status"][
+                        f"temperature_sensor {data.entity_description.key}"
+                    ]["temperature"],
                     subscriptions=[(obj, "temperature")],
                     icon="mdi:thermometer",
                     unit=DEGREE,
                 )
             )
     return sensor_list
-
-
-class MoonrakerOptionalTempSensor:
-    """MoonrakerOptionalTempSensor Sensor class."""
-
-    def __init__(self, sensor_name):
-        self.sensor_name = sensor_name
-
-    def __call__(self, data):
-        try:
-            return data["status"][self.sensor_name]["temperature"]
-        except KeyError:
-            return None
 
 
 class MoonrakerSensor(BaseMoonrakerEntity, SensorEntity):
@@ -256,16 +267,14 @@ class MoonrakerSensor(BaseMoonrakerEntity, SensorEntity):
         self._attr_name = description.name
         self._attr_has_entity_name = True
         self.entity_description = description
-        self._attr_native_value = description.value_fn(coordinator.data)
+        self._attr_native_value = description.value_fn(self)
         self._attr_icon = description.icon
         self._attr_native_unit_of_measurement = description.unit
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_native_value = self.entity_description.value_fn(
-            self.coordinator.data
-        )
+        self._attr_native_value = self.entity_description.value_fn(self)
         self.async_write_ha_state()
 
 

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -34,42 +34,48 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="state",
         name="Printer State",
-        value_fn=lambda data: data.coordinator.data["printer.info"]["state"],
+        value_fn=lambda sensor: sensor.coordinator.data["printer.info"]["state"],
         subscriptions=[],
     ),
     MoonrakerSensorDescription(
         key="message",
         name="Printer Message",
-        value_fn=lambda data: data.coordinator.data["printer.info"]["state_message"],
+        value_fn=lambda sensor: sensor.coordinator.data["printer.info"][
+            "state_message"
+        ],
         subscriptions=[],
     ),
     MoonrakerSensorDescription(
         key="print_state",
         name="Current Print State",
-        value_fn=lambda data: data.coordinator.data["status"]["print_stats"]["state"],
+        value_fn=lambda sensor: sensor.coordinator.data["status"]["print_stats"][
+            "state"
+        ],
         subscriptions=[("print_stats", "state")],
     ),
     MoonrakerSensorDescription(
         key="print_message",
         name="Current Print Message",
-        value_fn=lambda data: data.coordinator.data["status"]["print_stats"]["message"],
+        value_fn=lambda sensor: sensor.coordinator.data["status"]["print_stats"][
+            "message"
+        ],
         subscriptions=[("print_stats", "message")],
     ),
     MoonrakerSensorDescription(
         key="display_message",
         name="Current Display Message",
-        value_fn=lambda data: data.coordinator.data["status"]["display_status"][
+        value_fn=lambda sensor: sensor.coordinator.data["status"]["display_status"][
             "message"
         ]
-        if data.coordinator.data["status"]["display_status"]["message"] is not None
+        if sensor.coordinator.data["status"]["display_status"]["message"] is not None
         else "",
         subscriptions=[("display_status", "message")],
     ),
     MoonrakerSensorDescription(
         key="extruder_temp",
         name="Extruder Temperature",
-        value_fn=lambda data: float(
-            data.coordinator.data["status"]["extruder"]["temperature"]
+        value_fn=lambda sensor: float(
+            sensor.coordinator.data["status"]["extruder"]["temperature"]
         ),
         subscriptions=[("extruder", "temperature")],
         icon="mdi:printer-3d-nozzle-heat",
@@ -78,8 +84,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="extruder_target",
         name="Extruder Target",
-        value_fn=lambda data: float(
-            data.coordinator.data["status"]["extruder"]["target"]
+        value_fn=lambda sensor: float(
+            sensor.coordinator.data["status"]["extruder"]["target"]
         ),
         subscriptions=[("extruder", "target")],
         icon="mdi:printer-3d-nozzle-heat",
@@ -88,8 +94,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="bed_target",
         name="Bed Target",
-        value_fn=lambda data: float(
-            data.coordinator.data["status"]["heater_bed"]["target"]
+        value_fn=lambda sensor: float(
+            sensor.coordinator.data["status"]["heater_bed"]["target"]
         ),
         subscriptions=[("heater_bed", "target")],
         icon="mdi:radiator",
@@ -98,8 +104,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="bed_temp",
         name="Bed Temperature",
-        value_fn=lambda data: float(
-            data.coordinator.data["status"]["heater_bed"]["temperature"]
+        value_fn=lambda sensor: float(
+            sensor.coordinator.data["status"]["heater_bed"]["temperature"]
         ),
         subscriptions=[("heater_bed", "temperature")],
         icon="mdi:radiator",
@@ -108,7 +114,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="filename",
         name="Filename",
-        value_fn=lambda data: data.coordinator.data["status"]["print_stats"][
+        value_fn=lambda sensor: sensor.coordinator.data["status"]["print_stats"][
             "filename"
         ],
         subscriptions=[("print_stats", "filename")],
@@ -116,10 +122,10 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="print_projected_total_duration",
         name="print Projected Total Duration",
-        value_fn=lambda data: round(
-            data.coordinator.data["status"]["print_stats"]["print_duration"]
-            / calculate_pct_job(data.coordinator.data)
-            if calculate_pct_job(data.coordinator.data) != 0
+        value_fn=lambda sensor: round(
+            sensor.coordinator.data["status"]["print_stats"]["print_duration"]
+            / calculate_pct_job(sensor.coordinator.data)
+            if calculate_pct_job(sensor.coordinator.data) != 0
             else 0,
             2,
         ),
@@ -134,14 +140,14 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="print_time_left",
         name="Print Time Left",
-        value_fn=lambda data: round(
+        value_fn=lambda sensor: round(
             (
-                data.coordinator.data["status"]["print_stats"]["print_duration"]
-                / calculate_pct_job(data.coordinator.data)
-                if calculate_pct_job(data.coordinator.data) != 0
+                sensor.coordinator.data["status"]["print_stats"]["print_duration"]
+                / calculate_pct_job(sensor.coordinator.data)
+                if calculate_pct_job(sensor.coordinator.data) != 0
                 else 0
             )
-            - data.coordinator.data["status"]["print_stats"]["print_duration"],
+            - sensor.coordinator.data["status"]["print_stats"]["print_duration"],
             2,
         ),
         subscriptions=[
@@ -155,7 +161,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="print_eta",
         name="Print ETA",
-        value_fn=lambda data: calculate_eta(data.coordinator.data),
+        value_fn=lambda sensor: calculate_eta(sensor.coordinator.data),
         subscriptions=[
             ("print_stats", "print_duration"),
             ("display_status", "progress"),
@@ -166,8 +172,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="print_duration",
         name="Print Duration",
-        value_fn=lambda data: round(
-            data.coordinator.data["status"]["print_stats"]["print_duration"] / 60, 2
+        value_fn=lambda sensor: round(
+            sensor.coordinator.data["status"]["print_stats"]["print_duration"] / 60, 2
         ),
         subscriptions=[("print_stats", "print_duration")],
         icon="mdi:timer",
@@ -177,8 +183,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="filament_used",
         name="Filament Used",
-        value_fn=lambda data: round(
-            int(data.coordinator.data["status"]["print_stats"]["filament_used"])
+        value_fn=lambda sensor: round(
+            int(sensor.coordinator.data["status"]["print_stats"]["filament_used"])
             * 1.0
             / 1000,
             2,
@@ -190,8 +196,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="progress",
         name="Progress",
-        value_fn=lambda data: int(
-            data.coordinator.data["status"]["display_status"]["progress"] * 100
+        value_fn=lambda sensor: int(
+            sensor.coordinator.data["status"]["display_status"]["progress"] * 100
         ),
         subscriptions=[("display_status", "progress")],
         icon="mdi:percent",
@@ -200,8 +206,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="bed_power",
         name="Bed Power",
-        value_fn=lambda data: int(
-            data.coordinator.data["status"]["heater_bed"]["power"] * 100
+        value_fn=lambda sensor: int(
+            sensor.coordinator.data["status"]["heater_bed"]["power"] * 100
         ),
         subscriptions=[("heater_bed", "power")],
         icon="mdi:flash",
@@ -210,8 +216,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="extruder_power",
         name="Extruder Power",
-        value_fn=lambda data: int(
-            data.coordinator.data["status"]["extruder"]["power"] * 100
+        value_fn=lambda sensor: int(
+            sensor.coordinator.data["status"]["extruder"]["power"] * 100
         ),
         subscriptions=[("extruder", "power")],
         icon="mdi:flash",
@@ -246,8 +252,8 @@ async def async_setup_optional_temp_sensors(object_list):
                 MoonrakerSensorDescription(
                     key=split_obj[1],
                     name=split_obj[1].replace("_", " ").title(),
-                    value_fn=lambda data: data.coordinator.data["status"][
-                        f"temperature_sensor {data.entity_description.key}"
+                    value_fn=lambda sensor: sensor.coordinator.data["status"][
+                        f"temperature_sensor {sensor.entity_description.key}"
                     ]["temperature"],
                     subscriptions=[(obj, "temperature")],
                     icon="mdi:thermometer",

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -234,11 +234,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     object_list = await coordinator.async_fetch_data(METHOD.PRINTER_OBJECTS_LIST)
     opt_sensors = await async_setup_optional_sensors(object_list)
-    if not opt_sensors:
-        return
 
     coordinator.load_sensor_data(opt_sensors)
-
     await coordinator.async_refresh()
 
     async_add_entities(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,9 @@ def get_data_fixture():
                 "target": 60.0,
                 "power": 0.26053745272533363,
             },
+            "temperature_sensor mcu_temp": {
+                "temperature": 32.43,
+            },
             "display_status": {
                 "progress": 0.9078104237663283,
                 "message": "Custom Message",
@@ -119,6 +122,41 @@ def get_printer_info_fixture():
         "config_file": "/home/pi/printer_data/config/printer.cfg",
         "software_version": "v0.11.0-89-gead81fbf",
         "cpu_info": "4 core ARMv7 Processor rev 3 (v7l)",
+    }
+
+
+@pytest.fixture(name="get_printer_objects_list")
+def get_printer_objects_list_fixture():
+    """Get printer objects list fixture"""
+    return {
+        "objects": [
+            "webhooks",
+            "configfile",
+            "mcu",
+            "gcode_move",
+            "print_stats",
+            "virtual_sdcard",
+            "pause_resume",
+            "display_status",
+            "gcode_macro CANCEL_PRINT",
+            "gcode_macro PAUSE",
+            "gcode_macro RESUME",
+            "idle_timeout",
+            "heaters",
+            "heater_bed",
+            "fan",
+            "probe",
+            "bed_mesh",
+            "screws_tilt_adjust",
+            "temperature_sensor mcu_temp",
+            "stepper_enable",
+            "motion_report",
+            "query_endstops",
+            "system_stats",
+            "manual_probe",
+            "toolhead",
+            "extruder",
+        ]
     }
 
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -167,14 +167,24 @@ async def test_thumbnail_no_thumbnail(
 
 
 async def test_thumbnail_no_thumbnail_after_update(
-    hass, aioclient_mock, get_data, get_printer_info, get_camera_info
+    hass,
+    aioclient_mock,
+    get_data,
+    get_printer_info,
+    get_camera_info,
+    get_printer_objects_list,
 ):
     """Test setup thumbnail camera"""
 
     get_data["status"]["print_stats"]["filename"] = "CE3E3V2_picture_frame_holder.gcode"
     with patch(
         "moonraker_api.MoonrakerClient.call_method",
-        return_value={**get_data, **get_printer_info, **get_camera_info},
+        return_value={
+            **get_data,
+            **get_printer_info,
+            **get_camera_info,
+            **get_printer_objects_list,
+        },
     ):
         config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
         assert await async_setup_entry(hass, config_entry)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -120,7 +120,7 @@ async def test_opt_sensor_missing(
         await hass.async_block_till_done()
 
     state = hass.states.get("sensor.mainsail_mcu_temp")
-    assert state.state == "unknown"
+    assert state is None
 
 
 async def test_eta(hass, get_data, get_printer_info, get_printer_objects_list):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -111,6 +111,7 @@ async def test_opt_sensor_missing(
     hass, get_data, get_printer_info, get_printer_objects_list
 ):
     get_data["status"].pop("temperature_sensor mcu_temp", None)
+    get_printer_objects_list["objects"].remove("temperature_sensor mcu_temp")
     with patch(
         "moonraker_api.MoonrakerClient.call_method",
         return_value={**get_data, **get_printer_info, **get_printer_objects_list},


### PR DESCRIPTION
Moonraker allow to define customs temperature sensors that may be may not be present on every setup. This add those entity if those are present in the list of printer objects

printer.cfg with only one optional sensor an another one is commented out:
![image](https://user-images.githubusercontent.com/4152795/224458496-9e47c1b5-2f12-4992-b95d-ccc26edf5f43.png)

Available on mainsail dashboard:
![image](https://user-images.githubusercontent.com/4152795/224458543-8673015e-5bc3-42f4-b704-8416166c4273.png)


Once in hass:
![image](https://user-images.githubusercontent.com/4152795/224458564-478a852d-0e5b-4684-b496-b8e89a854c89.png)

If the sensor is removed from the printer.cfg:
![image](https://user-images.githubusercontent.com/4152795/224458615-e0162ac0-ec87-4df9-8d7c-0a7d18699101.png)

