### PR TITLE
Add the main fan sensor

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -223,6 +223,16 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         icon="mdi:flash",
         unit=PERCENTAGE,
     ),
+    MoonrakerSensorDescription(
+        key="fan_speed",
+        name="Fan speed",
+        value_fn=lambda sensor: float(
+            sensor.coordinator.data["status"]["fan"]["speed"] * 100
+        ),
+        subscriptions=[("fan", "speed")],
+        icon="mdi:fan",
+        unit=PERCENTAGE,
+    ),
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,10 @@ def get_data_fixture():
                 "progress": 0.9078104237663283,
                 "message": "Custom Message",
             },
+            "fan": {
+                "speed": 0.5123,
+                "rpm": 3000,
+            },
         },
         "printer.info": {
             "result": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -89,6 +89,7 @@ async def test_sensor_services_update(
         ("mainsail_progress", "90"),
         ("mainsail_bed_power", "26"),
         ("mainsail_extruder_power", "66"),
+        ("mainsail_fan_speed", "51.23"),
     ],
 )
 async def test_sensors(


### PR DESCRIPTION
The Moonraker documentation says that it's only present when it's specified in printer.cfg, so it can return "unknown"

![image](https://user-images.githubusercontent.com/4152795/224460196-80bdf714-8aa1-4f3c-91ad-40f066fff5ee.png)
