### PR TITLE
Add gcode macro support as button entity

### DIFF
--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -153,12 +153,15 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
         except Exception as exception:
             raise UpdateFailed() from exception
 
-    async def _async_send_data(self, query_path) -> None:
+    async def _async_send_data(self, query_path, query_obj) -> None:
         if not self.moonraker.client.is_connected:
             _LOGGER.warning("connection to moonraker down, restarting")
             await self.moonraker.start()
         try:
-            await self.moonraker.client.call_method(query_path)
+            if query_obj is None:
+                await self.moonraker.client.call_method(str(query_path))
+            else:
+                await self.moonraker.client.call_method(str(query_path), **query_obj)
         except Exception as exception:
             raise UpdateFailed() from exception
 
@@ -166,9 +169,11 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from moonraker"""
         return await self._async_fetch_data(query_path, None)
 
-    async def async_send_data(self, query_path: METHOD):
+    async def async_send_data(
+        self, query_path: METHOD, query_obj: dict[str:any] = None
+    ):
         """Send data to moonraker"""
-        return await self._async_send_data(query_path)
+        return await self._async_send_data(query_path, query_obj)
 
     def load_sensor_data(self, sensor_list):
         """Loading sensor data, so we can poll the right object"""

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -27,6 +27,8 @@ class METHOD(Enum):
     SERVER_FILES_METADATA = "server.files.metadata"
     SERVER_WEBCAMS_LIST = "server.webcams.list"
     PRINTER_EMERGENCY_STOP = "printer.emergency_stop"
+    PRINTER_GCODE_HELP = "printer.gcode.help"
+    PRINTER_GCODE_SCRIPT = "printer.gcode.script"
     PRINTER_INFO = "printer.info"
     PRINTER_OBJECTS_LIST = "printer.objects.list"
     PRINTER_OBJECTS_QUERY = "printer.objects.query"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,20 @@ def get_printer_info_fixture():
     }
 
 
+@pytest.fixture(name="get_gcode_help")
+def get_gcode_help_fixture():
+    """Get gcode help fixture"""
+    return {
+        "SET_PAUSE_NEXT_LAYER": "Enable a pause if the next layer is reached",
+        "SET_PAUSE_AT_LAYER": "Enable/disable a pause if a given layer number is reached",
+        "_TOOLHEAD_PARK_PAUSE_CANCEL": "Helper: park toolhead used in PAUSE and CANCEL_PRINT",
+        "_CLIENT_EXTRUDE": "Extrudes, if the extruder is hot enough",
+        "_CLIENT_RETRACT": "Retracts, if the extruder is hot enough",
+        "START_PRINT": "G-Code macro",
+        "END_PRINT": "G-Code macro",
+    }
+
+
 @pytest.fixture(name="get_printer_objects_list")
 def get_printer_objects_list_fixture():
     """Get printer objects list fixture"""


### PR DESCRIPTION
This makes available all defined gcode_macro as a button. If the macro has parameters, the default value will be used.

Only user-defined macros will be used, we filter them using the description of the command in the help menu. 

This a partial fix of #17 