### PR TITLE
fix_duplicate_temp_sensor

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -258,7 +258,6 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
     temperature_keys = [
         "temperature_sensor",
         "temperature_fan",
-        "temperature_host",
         "bme280",
         "htu21d",
         "lm75",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -91,7 +91,6 @@ async def test_sensor_services_update(
         ("mainsail_extruder_power", "66"),
         ("mainsail_fan_speed", "51.23"),
         ("mainsail_fan_temp", "32.43"),
-        ("mainsail_host_temp", "32.43"),
         ("mainsail_bme280_temp", "32.43"),
         ("mainsail_htu21d_temp", "32.43"),
         ("mainsail_lm75_temp", "32.43"),


### PR DESCRIPTION
Fixing #63 

We have 2 sensors for the host temperature 
![image](https://user-images.githubusercontent.com/2634090/227391536-0f129f83-ddc8-435f-be59-27b63eb16d0e.png)

I suggest removing one 