### PR TITLE
Set print state as enum

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -52,6 +52,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         value_fn=lambda sensor: sensor.coordinator.data["status"]["print_stats"][
             "state"
         ],
+        device_class=SensorDeviceClass.ENUM,
+        options=["standby", "printing", "paused", "complete", "cancelled", "error"],
         subscriptions=[("print_stats", "state")],
     ),
     MoonrakerSensorDescription(


### PR DESCRIPTION
This allows the state entity to show its possible value when configuring an automation

![image](https://user-images.githubusercontent.com/4152795/227677777-88ddf480-d78f-4dc6-a038-d0b93e84c4a5.png)


fix #61 