### PR TITLE
Add support for runout filament sensor

### DIFF
--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -73,8 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
     for platform in PLATFORMS:
-        if entry.options.get(platform, True):
-            coordinator.platforms.append(platform)
+        coordinator.platforms.append(platform)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/custom_components/moonraker/binary_sensor.py
+++ b/custom_components/moonraker/binary_sensor.py
@@ -1,0 +1,83 @@
+"""Binary sensors platform for Moonraker integration."""
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+
+from .const import DOMAIN, METHODS
+from .entity import BaseMoonrakerEntity
+
+
+@dataclass
+class MoonrakerBinarySensorDescription(BinarySensorEntityDescription):
+    """Class describing Mookraker binary_sensor entities."""
+
+    is_on_fn: Callable | None = None
+    sensor_name: str | None = None
+    subscriptions: list | None = None
+    icon: str | None = None
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Set up the binary_sensor platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    await async_setup_optional_binary_sensors(coordinator, entry, async_add_devices)
+
+
+async def async_setup_optional_binary_sensors(coordinator, entry, async_add_entities):
+    """Setup optional binary sensor platform."""
+
+    sensors = []
+    object_list = await coordinator.async_fetch_data(METHODS.PRINTER_OBJECTS_LIST)
+    for obj in object_list["objects"]:
+        split_obj = obj.split()
+
+        if split_obj[0] == "filament_switch_sensor":
+            desc = MoonrakerBinarySensorDescription(
+                key=f"{split_obj[0]}_{split_obj[1]}",
+                sensor_name=obj,
+                is_on_fn=lambda sensor: sensor.coordinator.data["status"][
+                    sensor.sensor_name
+                ]["filament_detected"],
+                name=split_obj[1].replace("_", " ").title(),
+                subscriptions=[(obj, "filament_detected")],
+                icon="mdi:printer-3d-nozzle-alert",
+                device_class=BinarySensorDeviceClass.OCCUPANCY,
+            )
+            sensors.append(desc)
+
+    coordinator.load_sensor_data(sensors)
+    await coordinator.async_refresh()
+    async_add_entities(
+        [MoonrakerBinarySensor(coordinator, entry, desc) for desc in sensors]
+    )
+
+
+class MoonrakerBinarySensor(BaseMoonrakerEntity, BinarySensorEntity):
+    """integration_blueprint binary_sensor class."""
+
+    def __init__(
+        self,
+        coordinator,
+        entry,
+        description,
+    ) -> None:
+        """Initialize the binary_sensor class."""
+        super().__init__(coordinator, entry)
+        self.entity_description = description
+        self.is_on_fn = description.is_on_fn
+        self.sensor_name = description.sensor_name
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_name = description.name
+        self._attr_has_entity_name = True
+        self._attr_native_value = description.is_on_fn(self)
+        self._attr_icon = description.icon
+
+    @property
+    def is_on(self) -> bool:
+        return self.is_on_fn(self)

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -10,7 +10,7 @@ VERSION = "0.6.1"
 MANIFACTURER = "@marcolivierarsenault"
 
 # Platforms
-PLATFORMS = [Platform.SENSOR, Platform.CAMERA, Platform.BUTTON]
+PLATFORMS = [Platform.SENSOR, Platform.CAMERA, Platform.BUTTON, Platform.BINARY_SENSOR]
 
 CONF_API_KEY = "api_key"
 CONF_URL = "url"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,14 @@ def get_data_fixture():
                 "speed": 0.5123,
                 "rpm": 3000,
             },
+            "filament_switch_sensor filament_sensor_1": {
+                "filament_detected": True,
+                "enabled": True,
+            },
+            "filament_switch_sensor filament_sensor_2": {
+                "filament_detected": True,
+                "enabled": True,
+            },
         },
         "printer.info": {
             "result": {
@@ -214,6 +222,8 @@ def get_printer_objects_list_fixture():
             "lm75 lm75_temp",
             "heater_fan heater_fan",
             "controller_fan controller_fan",
+            "filament_switch_sensor filament_sensor_1",
+            "filament_switch_sensor filament_sensor_2",
         ]
     }
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,95 @@
+""" Binary_sensor Tests"""
+from unittest.mock import patch
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.moonraker import async_setup_entry
+from custom_components.moonraker.const import DOMAIN
+
+from .const import MOCK_CONFIG
+
+
+@pytest.fixture(name="bypass_connect_client", autouse=True)
+def bypass_connect_client_fixture():
+    """Skip calls to get data from API."""
+    with patch("custom_components.moonraker.MoonrakerApiClient.start"):
+        yield
+
+
+async def test_runout_filament_sensor_missing(
+    hass, get_data, get_printer_info, get_printer_objects_list
+):
+    get_data["status"].pop("filament_switch_sensor filament_sensor_1", None)
+    get_data["status"].pop("filament_switch_sensor filament_sensor_2", None)
+    get_printer_objects_list["objects"].remove(
+        "filament_switch_sensor filament_sensor_1"
+    )
+    get_printer_objects_list["objects"].remove(
+        "filament_switch_sensor filament_sensor_2"
+    )
+
+    with patch(
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_data, **get_printer_info, **get_printer_objects_list},
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+        assert await async_setup_entry(hass, config_entry)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.mainsail_filament_sensor_1")
+    assert state is None
+    state = hass.states.get("binary_sensor.mainsail_filament_sensor_2")
+    assert state is None
+
+
+async def test_runout_filament_sensor(
+    hass, get_data, get_printer_info, get_printer_objects_list
+):
+    with patch(
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_data, **get_printer_info, **get_printer_objects_list},
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+        assert await async_setup_entry(hass, config_entry)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.mainsail_filament_sensor_1")
+    assert state.state == "on"
+
+
+async def test_multiple_runout_filament_sensor(
+    hass, get_data, get_printer_info, get_printer_objects_list
+):
+    with patch(
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_data, **get_printer_info, **get_printer_objects_list},
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+        assert await async_setup_entry(hass, config_entry)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.mainsail_filament_sensor_1")
+    assert state.state == "on"
+
+    state = hass.states.get("binary_sensor.mainsail_filament_sensor_2")
+    assert state.state == "on"
+
+
+async def test_runout_filament_sensor_off(
+    hass, get_data, get_printer_info, get_printer_objects_list
+):
+    get_data["status"]["filament_switch_sensor filament_sensor_1"][
+        "filament_detected"
+    ] = False
+
+    with patch(
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_data, **get_printer_info, **get_printer_objects_list},
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+        assert await async_setup_entry(hass, config_entry)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.mainsail_filament_sensor_1")
+    assert state.state == "off"


### PR DESCRIPTION
This add filament sensors (may be more than one) as binary sensor

Right now, it is implemented as an "occupancy" class with means that the values are "Detected" and "clear"

![image](https://user-images.githubusercontent.com/4152795/228970853-d0ba9e63-8ace-4473-8361-a1854dbe8044.png)

It's pretty similar to mainsail:
![image](https://user-images.githubusercontent.com/4152795/228970967-7888f12a-ebc3-46df-94dd-48dbf21022d1.png)


This address feature request #80 

As a future improvement, we could add the same toggle switch to disable the sensor if needed