### PR TITLE
Features/output pin

### DIFF
--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -184,7 +184,9 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER.error("gcode {%s}", gcode)
             return return_gcode
 
-    async def _async_fetch_data(self, query_path: METHODS, query_object):
+    async def _async_fetch_data(
+        self, query_path: METHODS, query_object, quiet: bool = False
+    ):
         if not self.moonraker.client.is_connected:
             _LOGGER.warning("connection to moonraker down, restarting")
             await self.moonraker.start()
@@ -195,7 +197,8 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
                 result = await self.moonraker.client.call_method(
                     query_path.value, **query_object
                 )
-            _LOGGER.debug(result)
+            if not quiet:
+                _LOGGER.debug(result)
             return result
         except Exception as exception:
             raise UpdateFailed() from exception
@@ -213,10 +216,10 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed() from exception
 
     async def async_fetch_data(
-        self, query_path: METHODS, query_obj: dict[str:any] = None
+        self, query_path: METHODS, query_obj: dict[str:any] = None, quiet: bool = False
     ):
         """Fetch data from moonraker"""
-        return await self._async_fetch_data(query_path, query_obj)
+        return await self._async_fetch_data(query_path, query_obj, quiet=quiet)
 
     async def async_send_data(
         self, query_path: METHODS, query_obj: dict[str:any] = None

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -16,6 +16,7 @@ PLATFORMS = [
     Platform.BUTTON,
     Platform.BINARY_SENSOR,
     Platform.SWITCH,
+    Platform.NUMBER,
 ]
 
 CONF_API_KEY = "api_key"

--- a/custom_components/moonraker/number.py
+++ b/custom_components/moonraker/number.py
@@ -1,0 +1,106 @@
+"""Number platform for Moonraker integration."""
+from dataclasses import dataclass
+import logging
+
+from homeassistant.components.number import (
+    NumberEntity,
+    NumberEntityDescription,
+    NumberMode,
+)
+from homeassistant.core import callback
+
+from .const import DOMAIN, METHODS, OBJ
+from .entity import BaseMoonrakerEntity
+
+
+@dataclass
+class MoonrakerNumberSensorDescription(NumberEntityDescription):
+    """Class describing Mookraker binary_sensor entities."""
+
+    sensor_name: str | None = None
+    icon: str | None = None
+    subscriptions: list | None = None
+
+
+async def async_setup_entry(hass, entry, async_add_devices):
+    """Set up the number platform."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    await async_setup_output_pin(coordinator, entry, async_add_devices)
+
+
+async def async_setup_output_pin(coordinator, entry, async_add_entities):
+    """Setup optional binary sensor platform."""
+
+    object_list = await coordinator.async_fetch_data(METHODS.PRINTER_OBJECTS_LIST)
+
+    query_obj = {OBJ: {"configfile": ["settings"]}}
+    settings = await coordinator.async_fetch_data(
+        METHODS.PRINTER_OBJECTS_QUERY, query_obj, quiet=True
+    )
+
+    numbers = []
+    for obj in object_list["objects"]:
+        if "output_pin" not in obj:
+            continue
+
+        if not settings["status"]["configfile"]["settings"][obj]["pwm"]:
+            continue
+
+        desc = MoonrakerNumberSensorDescription(
+            key=obj,
+            sensor_name=obj,
+            name=obj.replace("_", " ").title(),
+            icon="mdi:switch",
+            subscriptions=[(obj, "value")],
+        )
+        numbers.append(desc)
+
+    coordinator.load_sensor_data(numbers)
+    await coordinator.async_refresh()
+    async_add_entities(
+        [MoonrakerPWMOutputPin(coordinator, entry, desc) for desc in numbers]
+    )
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MoonrakerPWMOutputPin(BaseMoonrakerEntity, NumberEntity):
+    """Moonraker PWM output pin class."""
+
+    def __init__(
+        self,
+        coordinator,
+        entry,
+        description,
+    ) -> None:
+        """Initialize the switch class."""
+        super().__init__(coordinator, entry)
+        self.pin = description.sensor_name.replace("output_pin ", "")
+        self._attr_mode = NumberMode.SLIDER
+        self._attr_native_value = (
+            coordinator.data["status"][description.sensor_name]["value"] * 100
+        )
+        self.entity_description = description
+        self.sensor_name = description.sensor_name
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_name = description.name
+        self._attr_has_entity_name = True
+        self._attr_icon = description.icon
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.async_send_data(
+            METHODS.PRINTER_GCODE_SCRIPT,
+            {"script": f"SET_PIN PIN={self.pin} VALUE={round(value/100, 2)}"},
+        )
+        self._attr_native_value = value
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_native_value = (
+            self.coordinator.data["status"][self.sensor_name]["value"] * 100
+        )
+        self.async_write_ha_state()

--- a/custom_components/moonraker/switch.py
+++ b/custom_components/moonraker/switch.py
@@ -123,7 +123,6 @@ class MoonrakerPowerDeviceSwitchSensor(MoonrakerSwitchSensor):
         for device in self.coordinator.data["power_devices"]["devices"]:
             if device["device"] == self.sensor_name:
                 return device["status"] == "on"
-        return False
 
     async def async_turn_on(self, **_: any) -> None:
         """Turn on the switch."""

--- a/custom_components/moonraker/switch.py
+++ b/custom_components/moonraker/switch.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 
-from .const import DOMAIN, METHODS
+from .const import DOMAIN, METHODS, OBJ
 from .entity import BaseMoonrakerEntity
 
 
@@ -21,6 +21,7 @@ async def async_setup_entry(hass, entry, async_add_devices):
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
     await async_setup_power_device(coordinator, entry, async_add_devices)
+    await async_setup_output_pin(coordinator, entry, async_add_devices)
 
 
 async def _power_device_updater(coordinator):
@@ -29,6 +30,40 @@ async def _power_device_updater(coordinator):
             METHODS.MACHINE_DEVICE_POWER_DEVICES
         )
     }
+
+
+async def async_setup_output_pin(coordinator, entry, async_add_entities):
+    """Setup optional binary sensor platform."""
+
+    object_list = await coordinator.async_fetch_data(METHODS.PRINTER_OBJECTS_LIST)
+
+    query_obj = {OBJ: {"configfile": ["settings"]}}
+    settings = await coordinator.async_fetch_data(
+        METHODS.PRINTER_OBJECTS_QUERY, query_obj, quiet=True
+    )
+
+    switches = []
+    for obj in object_list["objects"]:
+        if "output_pin" not in obj:
+            continue
+
+        if settings["status"]["configfile"]["settings"][obj]["pwm"]:
+            continue
+
+        desc = MoonrakerSwitchSensorDescription(
+            key=obj,
+            sensor_name=obj,
+            name=obj.replace("_", " ").title(),
+            icon="mdi:switch",
+            subscriptions=[(obj, "value")],
+        )
+        switches.append(desc)
+
+    coordinator.load_sensor_data(switches)
+    await coordinator.async_refresh()
+    async_add_entities(
+        [MoonrakerDigitalOutputPin(coordinator, entry, desc) for desc in switches]
+    )
 
 
 async def async_setup_power_device(coordinator, entry, async_add_entities):
@@ -56,7 +91,7 @@ async def async_setup_power_device(coordinator, entry, async_add_entities):
     coordinator.load_sensor_data(sensors)
     await coordinator.async_refresh()
     async_add_entities(
-        [MoonrakerSwitchSensor(coordinator, entry, desc) for desc in sensors]
+        [MoonrakerPowerDeviceSwitchSensor(coordinator, entry, desc) for desc in sensors]
     )
 
 
@@ -78,12 +113,17 @@ class MoonrakerSwitchSensor(BaseMoonrakerEntity, SwitchEntity):
         self._attr_has_entity_name = True
         self._attr_icon = description.icon
 
+
+class MoonrakerPowerDeviceSwitchSensor(MoonrakerSwitchSensor):
+    """Moonraker power device switch class."""
+
     @property
     def is_on(self) -> bool:
         """Return true if the switch is on."""
         for device in self.coordinator.data["power_devices"]["devices"]:
             if device["device"] == self.sensor_name:
                 return device["status"] == "on"
+        return False
 
     async def async_turn_on(self, **_: any) -> None:
         """Turn on the switch."""
@@ -98,5 +138,34 @@ class MoonrakerSwitchSensor(BaseMoonrakerEntity, SwitchEntity):
         await self.coordinator.async_send_data(
             METHODS.MACHINE_DEVICE_POWER_POST_DEVICE,
             {"device": self.sensor_name, "action": "off"},
+        )
+        await self.coordinator.async_refresh()
+
+
+class MoonrakerDigitalOutputPin(MoonrakerSwitchSensor):
+    """Moonraker power device switch class."""
+
+    def __init__(self, coordinator, entry, description) -> None:
+        super().__init__(coordinator, entry, description)
+        self.pin = description.sensor_name.replace("output_pin ", "")
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the switch is on."""
+        return self.coordinator.data["status"][self.sensor_name]["value"] == 1
+
+    async def async_turn_on(self, **_: any) -> None:
+        """Turn on the switch."""
+        await self.coordinator.async_send_data(
+            METHODS.PRINTER_GCODE_SCRIPT,
+            {"script": f"SET_PIN PIN={self.pin} VALUE=1"},
+        )
+        await self.coordinator.async_refresh()
+
+    async def async_turn_off(self, **_: any) -> None:
+        """Turn off the switch."""
+        await self.coordinator.async_send_data(
+            METHODS.PRINTER_GCODE_SCRIPT,
+            {"script": f"SET_PIN PIN={self.pin} VALUE=0"},
         )
         await self.coordinator.async_refresh()

--- a/docs/entities/controls.rst
+++ b/docs/entities/controls.rst
@@ -53,8 +53,25 @@ A series of switches are available by default. They are:
   * - Printer Switch
     - Power On/Off the printer.
     - From Moonraker API (*machine.device_power.devices*)
+  * - Output pin digital
+    - Set a digital output pin to on or off.
+    - From Moonraker API (*printer.gcode.script*)
 
-Macros
+Default Numbers
+---------------------------------
+
+A series of Numbers are available by default as slidder. They are:
+
+.. list-table:: Default Switches
+  :header-rows: 1
+
+  * - Number Name
+    - Description
+    - Definition
+  * - Output pin pwm
+    - Set a pwm output pin to a value.
+    - From Moonraker API (*printer.gcode.script*)
+
 ---------------------------------
 
 Each macro configured in Klipper is available as a button.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,16 @@ def get_data_fixture():
     return {
         "eventtime": 128684.342831779,
         "status": {
+            "configfile": {
+                "settings": {
+                    "output_pin digital": {
+                        "pwm": False,
+                    },
+                    "output_pin pwm": {
+                        "pwm": True,
+                    },
+                },
+            },
             "print_stats": {
                 "filename": "CE3E3V2_picture_frame_holder.gcode",
                 "total_duration": 8232.396654963959,
@@ -117,6 +127,12 @@ def get_data_fixture():
             "filament_switch_sensor filament_sensor_2": {
                 "filament_detected": True,
                 "enabled": True,
+            },
+            "output_pin digital": {
+                "value": 1.0,
+            },
+            "output_pin pwm": {
+                "value": 0.5,
             },
         },
         "printer.info": {
@@ -245,6 +261,8 @@ def get_printer_objects_list_fixture():
             "controller_fan controller_fan",
             "filament_switch_sensor filament_sensor_1",
             "filament_switch_sensor filament_sensor_2",
+            "output_pin digital",
+            "output_pin pwm",
         ]
     }
 

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,51 @@
+""" Number Tests"""
+from unittest.mock import patch
+
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, SERVICE_SET_VALUE
+from homeassistant.const import ATTR_ENTITY_ID
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.moonraker import async_setup_entry
+from custom_components.moonraker.const import DOMAIN, METHODS
+
+from .const import MOCK_CONFIG
+
+
+@pytest.fixture(name="bypass_connect_client", autouse=True)
+def bypass_connect_client_fixture():
+    """Skip calls to get data from API."""
+    with patch("custom_components.moonraker.MoonrakerApiClient.start"):
+        yield
+
+
+# test number
+@pytest.mark.parametrize(
+    "number",
+    [
+        ("mainsail_output_pin_pwm"),
+    ],
+)
+async def test_number_set_value(hass, number, get_default_api_response):
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    assert await async_setup_entry(hass, config_entry)
+    await hass.async_block_till_done()
+
+    with patch(
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_default_api_response},
+    ) as mock_api:
+        await hass.services.async_call(
+            NUMBER_DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_ENTITY_ID: f"number.{number}",
+                "value": 50,
+            },
+            blocking=True,
+        )
+
+        mock_api.assert_any_call(
+            METHODS.PRINTER_GCODE_SCRIPT.value,
+            script=f"SET_PIN PIN={number.split('_')[3]} VALUE=0.5",
+        )


### PR DESCRIPTION
Add support for output_pin defined in printer.cfg.

There is mainly two types of output_pin, digital and pwm. The digital one are implemented as a switch and the pwm one as a number configured as a slider.

The only way to know from moonraker which mode is used for an output_pin is to read the settings of the output_pin from the configfile printer object.

![image](https://user-images.githubusercontent.com/4152795/233798776-ec975d54-a0ec-4c3c-a603-ee4342017545.png)

* the first one is gray out because it was my test with the digital mode
#114 