### PR TITLE
change doc theme to furo

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ author = "Marc-Olivier Arsenault, Eric Tremblay"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.autosectionlabel", "sphinx_rtd_theme"]
+extensions = ["sphinx.ext.autosectionlabel"]
 
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
@@ -22,5 +22,5 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 html_static_path = ["_static"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx==6.2.0
-sphinx-rtd-theme==1.2.0
+sphinx==7.0.1
+furo==2023.5.20
 urllib3==1.26.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ moonraker-api==2.0.5
 aiohttp_cors==0.7.0
 Pillow==9.5.0
 pre-commit==3.3.1
-sphinx==6.2.0
-sphinx-rtd-theme==1.2.0
+sphinx==7.0.1
 colorlog==6.7.0
 urllib3==1.26.15
+furo==2023.5.20


### PR DESCRIPTION
RTD theme is struguling to stay updated. 
Looks like people are starting to pivot to FURO theme (which does catch up with Sphinx) 
https://github.com/readthedocs/sphinx_rtd_theme/issues/1463#issuecomment-1558942488

