### PR TITLE
add all macros disabled by default

### DIFF
--- a/custom_components/moonraker/button.py
+++ b/custom_components/moonraker/button.py
@@ -105,8 +105,9 @@ async def async_setup_macros(coordinator, entry, async_add_entities):
 
     macros = []
     for cmd, desc in cmds.items():
-        if desc != "G-Code macro":
-            continue
+        enable_by_default = False
+        if desc == "G-Code macro":
+            enable_by_default = True
 
         macros.append(
             MoonrakerButtonDescription(
@@ -116,6 +117,7 @@ async def async_setup_macros(coordinator, entry, async_add_entities):
                     METHODS.PRINTER_GCODE_SCRIPT, {"script": button.invoke_name}
                 ),
                 icon="mdi:play",
+                entity_registry_enabled_default=enable_by_default,
             )
         )
 

--- a/docs/entities/controls.rst
+++ b/docs/entities/controls.rst
@@ -47,12 +47,12 @@ Macros
 
 Each macro configured in Klipper is available as a button.
 
-Depending of the macro, it may be disabled by default. If Macro Description is `G-Code macro` it will be enabled by default. It will be disabled otherwise.
+If the Macro description is `G-Code macro` it will be enabled by default, otherwise it will be disabled.
 You can enable a specific macro by enabling it's entity in HomeAssistant configuration. (Like any other disabled entity.)
 
 .. note::
 
-   Current limitation, we cannot change any parameter for those macros.
+   Current limitation, we cannot change any parameters for those macros.
 
 
 Default Switches

--- a/docs/entities/controls.rst
+++ b/docs/entities/controls.rst
@@ -42,6 +42,19 @@ A series of buttons are available by default. They are:
     - Power On/Off the printer.
     - From Moonraker API (*machine.device_power.devices*)
 
+Macros
+---------------------------------
+
+Each macro configured in Klipper is available as a button.
+
+Depending of the macro, it may be disabled by default. If Macro Description is `G-Code macro` it will be enabled by default. It will be disabled otherwise.
+You can enable a specific macro by enabling it's entity in HomeAssistant configuration. (Like any other disabled entity.)
+
+.. note::
+
+   Current limitation, we cannot change any parameter for those macros.
+
+
 Default Switches
 ---------------------------------
 
@@ -65,7 +78,7 @@ Default Numbers
 
 A series of Numbers are available by default as slidder. They are:
 
-.. list-table:: Default Switches
+.. list-table:: Default Numbers
   :header-rows: 1
 
   * - Number Name
@@ -74,11 +87,3 @@ A series of Numbers are available by default as slidder. They are:
   * - Output pin pwm
     - Set a pwm output pin to a value.
     - From Moonraker API (*printer.gcode.script*)
-
----------------------------------
-
-Each macro configured in Klipper is available as a button.
-
-.. note::
-
-   Current limitation, we cannot change any parameter for those macros.

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.helpers import entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -70,3 +71,18 @@ async def test_gcode_macro(hass):
         mock_api.assert_called_once_with(
             METHODS.PRINTER_GCODE_SCRIPT.value, script="START_PRINT"
         )
+
+
+async def test_disabled_buttons(hass):
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    assert await async_setup_entry(hass, config_entry)
+    await hass.async_block_till_done()
+
+    entity_registry = er.async_get(hass)
+    entity = entity_registry.async_get("button.mainsail_macro_end_print")
+    assert entity
+    assert not entity.disabled
+
+    entity = entity_registry.async_get("button.mainsail_macro_set_pause_next_layer")
+    assert entity
+    assert entity.disabled


### PR DESCRIPTION
Adding all possible macros by default as disabled button. 

When Macro definitions are: `G-Code macro` we keep them enable by default but when they have a different definition we disable them. 

This make it easy for people to enable specific macros without overloading the integration. 

Example:
![image](https://github.com/marcolivierarsenault/moonraker-home-assistant/assets/2634090/9d3aaf02-d8ea-4478-9743-427a33749ba7)

The initial list of button is unchanged, but then a long list exist. 

This is to address #145 