### PR TITLE
lower the object when accessing the configfile.settings object for ou…

### DIFF
--- a/custom_components/moonraker/number.py
+++ b/custom_components/moonraker/number.py
@@ -44,7 +44,7 @@ async def async_setup_output_pin(coordinator, entry, async_add_entities):
         if "output_pin" not in obj:
             continue
 
-        if not settings["status"]["configfile"]["settings"][obj]["pwm"]:
+        if not settings["status"]["configfile"]["settings"][obj.lower()]["pwm"]:
             continue
 
         desc = MoonrakerNumberSensorDescription(

--- a/custom_components/moonraker/switch.py
+++ b/custom_components/moonraker/switch.py
@@ -47,7 +47,7 @@ async def async_setup_output_pin(coordinator, entry, async_add_entities):
         if "output_pin" not in obj:
             continue
 
-        if settings["status"]["configfile"]["settings"][obj]["pwm"]:
+        if settings["status"]["configfile"]["settings"][obj.lower()]["pwm"]:
             continue
 
         desc = MoonrakerSwitchSensorDescription(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,9 @@ def get_data_fixture():
                     "output_pin pwm": {
                         "pwm": True,
                     },
+                    "output_pin capitalized": {
+                        "pwm": True,
+                    },
                 },
             },
             "print_stats": {
@@ -137,6 +140,9 @@ def get_data_fixture():
             },
             "output_pin pwm": {
                 "value": 0.5,
+            },
+            "output_pin CAPITALIZED": {
+                "value": 1.0,
             },
             "gcode_move": {
                 "speed_factor": 2.0,
@@ -270,6 +276,7 @@ def get_printer_objects_list_fixture():
             "filament_switch_sensor filament_sensor_2",
             "output_pin digital",
             "output_pin pwm",
+            "output_pin CAPITALIZED",
             "fan_generic nevermore_fan",
         ]
     }

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -22,9 +22,7 @@ def bypass_connect_client_fixture():
 # test number
 @pytest.mark.parametrize(
     "number",
-    [
-        ("mainsail_output_pin_pwm"),
-    ],
+    [("mainsail_output_pin_pwm"), ("mainsail_output_pin_CAPITALIZED")],
 )
 async def test_number_set_value(hass, number, get_default_api_response):
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")


### PR DESCRIPTION
…tput_pin

On some device, notably the creality k1, some output_pin configuration are capitalized. When reading the configfile.settings object those same configuration are in lower case, make sure to always check with the lower string for output_pin

This should fix #205 