### PR TITLE
modify pct calulation logic to account for missing filament usage

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -517,22 +517,22 @@ def calculate_pct_job(data) -> float:
     print_expected_duration = data["estimated_time"]
     filament_used = data["status"]["print_stats"]["filament_used"]
     expected_filament = data["filament_total"]
-    devider = 0
+    divider = 0
     time_pct = 0
     filament_pct = 0
 
     if print_expected_duration != 0:
         time_pct = data["status"]["display_status"]["progress"]
-        devider += 1
+        divider += 1
 
     if expected_filament != 0:
         filament_pct = 1.0 * filament_used / expected_filament
-        devider += 1
+        divider += 1
 
-    if devider == 0:
+    if divider == 0:
         return 0
 
-    return (time_pct + filament_pct) / devider
+    return (time_pct + filament_pct) / divider
 
 
 def calculate_eta(data):

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -518,6 +518,8 @@ def calculate_pct_job(data) -> float:
     filament_used = data["status"]["print_stats"]["filament_used"]
     expected_filament = data["filament_total"]
     devider = 0
+    time_pct = 0
+    filament_pct = 0
 
     if print_expected_duration != 0:
         time_pct = data["status"]["display_status"]["progress"]

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -517,13 +517,20 @@ def calculate_pct_job(data) -> float:
     print_expected_duration = data["estimated_time"]
     filament_used = data["status"]["print_stats"]["filament_used"]
     expected_filament = data["filament_total"]
-    if print_expected_duration == 0 or expected_filament == 0:
+    devider = 0
+
+    if print_expected_duration != 0:
+        time_pct = data["status"]["display_status"]["progress"]
+        devider += 1
+
+    if expected_filament != 0:
+        filament_pct = 1.0 * filament_used / expected_filament
+        devider += 1
+
+    if devider == 0:
         return 0
 
-    time_pct = data["status"]["display_status"]["progress"]
-    filament_pct = 1.0 * filament_used / expected_filament
-
-    return (time_pct + filament_pct) / 2
+    return (time_pct + filament_pct) / devider
 
 
 def calculate_eta(data):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -217,11 +217,17 @@ async def test_calculate_pct_job(data_for_calculate_pct):
 
 async def test_calculate_pct_job_no_time(data_for_calculate_pct):
     data_for_calculate_pct["estimated_time"] = 0
-    assert calculate_pct_job(data_for_calculate_pct) == 0
+    assert calculate_pct_job(data_for_calculate_pct) == 0.5
 
 
 async def test_calculate_pct_job_no_filament(data_for_calculate_pct):
     data_for_calculate_pct["filament_total"] = 0
+    assert calculate_pct_job(data_for_calculate_pct) == 0.6
+
+
+async def test_calculate_pct_job_no_filament_no_time(data_for_calculate_pct):
+    data_for_calculate_pct["filament_total"] = 0
+    data_for_calculate_pct["estimated_time"] = 0
     assert calculate_pct_job(data_for_calculate_pct) == 0
 
 


### PR DESCRIPTION
Attemp to fix #158

Some printer seems to have 0 `filament_total`  which is screewing our pct calculation 