### PR TITLE
Add state_class property to relevant sensors to enable long-term statistics

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -86,6 +86,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("extruder", "temperature")],
         icon="mdi:printer-3d-nozzle-heat",
         unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="extruder_target",
@@ -116,6 +117,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("heater_bed", "temperature")],
         icon="mdi:radiator",
         unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="filename",

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -97,6 +97,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("extruder", "target")],
         icon="mdi:printer-3d-nozzle-heat",
         unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="bed_target",
@@ -107,6 +108,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("heater_bed", "target")],
         icon="mdi:radiator",
         unit=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="bed_temp",
@@ -232,6 +234,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("print_stats", "filament_used")],
         icon="mdi:tape-measure",
         unit=UnitOfLength.METERS,
+        state_class=SensorStateClass.TOTAL,
     ),
     MoonrakerSensorDescription(
         key="progress",
@@ -252,6 +255,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("heater_bed", "power")],
         icon="mdi:flash",
         unit=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="extruder_power",
@@ -262,6 +266,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("extruder", "power")],
         icon="mdi:flash",
         unit=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="total_layer",
@@ -271,7 +276,6 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         ),
         subscriptions=[("print_stats", "info", "total_layer")],
         icon="mdi:layers-triple",
-        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="current_layer",
@@ -290,6 +294,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("toolhead", "position")],
         icon="mdi:axis-x-arrow",
         unit=UnitOfLength.MILLIMETERS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="toolhead_position_y",
@@ -300,6 +305,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("toolhead", "position")],
         icon="mdi:axis-y-arrow",
         unit=UnitOfLength.MILLIMETERS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="toolhead_position_z",
@@ -310,6 +316,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("toolhead", "position")],
         icon="mdi:axis-z-arrow",
         unit=UnitOfLength.MILLIMETERS,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="object_height",
@@ -370,6 +377,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                 subscriptions=[(obj, "temperature")],
                 icon="mdi:thermometer",
                 unit=UnitOfTemperature.CELSIUS,
+                state_class=SensorStateClass.MEASUREMENT,
             )
             sensors.append(desc)
         elif split_obj[0] in fan_keys:
@@ -384,6 +392,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                 subscriptions=[(obj, "speed")],
                 icon="mdi:fan",
                 unit=PERCENTAGE,
+                state_class=SensorStateClass.MEASUREMENT,
             )
             sensors.append(desc)
         elif obj == "fan":
@@ -396,6 +405,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                 subscriptions=[("fan", "speed")],
                 icon="mdi:fan",
                 unit=PERCENTAGE,
+                state_class=SensorStateClass.MEASUREMENT,
             )
             sensors.append(desc)
         elif obj == "gcode_move":
@@ -452,6 +462,7 @@ async def async_setup_history_sensors(coordinator, entry, async_add_entities):
             ),
             subscriptions=[],
             icon="mdi:clock-outline",
+            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         MoonrakerSensorDescription(
             key="total_filament_used",

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -275,6 +275,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         ),
         subscriptions=[("print_stats", "info", "total_layer")],
         icon="mdi:layers-triple",
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     MoonrakerSensorDescription(
         key="current_layer",

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -234,7 +234,6 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         subscriptions=[("print_stats", "filament_used")],
         icon="mdi:tape-measure",
         unit=UnitOfLength.METERS,
-        state_class=SensorStateClass.TOTAL,
     ),
     MoonrakerSensorDescription(
         key="progress",

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -462,7 +462,6 @@ async def async_setup_history_sensors(coordinator, entry, async_add_entities):
             ),
             subscriptions=[],
             icon="mdi:clock-outline",
-            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         MoonrakerSensorDescription(
             key="total_filament_used",


### PR DESCRIPTION
Hi, I like use temp charts in my home assistant printers dashboard, however it does not work if the entity doesn't have its state_class property defined. It could also be done per-sensor with customize.yaml, but this seemed to be a common enough use-case to try suggesting a PR.

Hope this works for you, thanks.