### PR TITLE
Add support for additional sensors from BME680

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -356,7 +356,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                     METHODS.PRINTER_OBJECTS_QUERY, query_obj, quiet=True
                 )
 
-                if "pressure" in result["status"][obj].keys():
+                if "pressure" in result["status"][obj]:
                     desc = MoonrakerSensorDescription(
                         key=f"{split_obj[0]}_{split_obj[1]}_pressure",
                         status_key=obj,
@@ -371,7 +371,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                     )
                     sensors.append(desc)
 
-                if "humidity" in result["status"][obj].keys():
+                if "humidity" in result["status"][obj]:
                     desc = MoonrakerSensorDescription(
                         key=f"{split_obj[0]}_{split_obj[1]}_humidity",
                         status_key=obj,
@@ -386,7 +386,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                     )
                     sensors.append(desc)
 
-                if "gas" in result["status"][obj].keys():
+                if "gas" in result["status"][obj]:
                     desc = MoonrakerSensorDescription(
                         key=f"{split_obj[0]}_{split_obj[1]}_gas",
                         status_key=obj,

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -11,10 +11,10 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfTemperature, UnitOfTime
+from homeassistant.const import PERCENTAGE, UnitOfLength, UnitOfPressure, UnitOfTemperature, UnitOfTime
 from homeassistant.core import callback
 
-from .const import DOMAIN, METHODS, PRINTERSTATES, PRINTSTATES
+from .const import OBJ, DOMAIN, METHODS, PRINTERSTATES, PRINTSTATES
 from .entity import BaseMoonrakerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -110,7 +110,7 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     ),
     MoonrakerSensorDescription(
         key="print_projected_total_duration",
-        name="print Projected Total Duration",
+        name="Print Projected Total Duration",
         value_fn=lambda sensor: sensor.empty_result_when_not_printing(
             round(
                 sensor.coordinator.data["status"]["print_stats"]["print_duration"]
@@ -339,7 +339,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
             desc = MoonrakerSensorDescription(
                 key=f"{split_obj[0]}_{split_obj[1]}",
                 status_key=obj,
-                name=split_obj[1].replace("_", " ").title(),
+                name=split_obj[1].replace("_", " ").title() + " Temperature",
                 value_fn=lambda sensor: sensor.coordinator.data["status"][
                     sensor.status_key
                 ]["temperature"],
@@ -349,6 +349,59 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                 state_class=SensorStateClass.MEASUREMENT,
             )
             sensors.append(desc)
+
+            if split_obj[0] == "bme280":
+                query_obj = {OBJ: {obj: None}}
+                result = await coordinator.async_fetch_data(
+                    METHODS.PRINTER_OBJECTS_QUERY, query_obj, quiet=True
+                )
+
+                if "pressure" in result["status"][obj].keys():
+                    desc = MoonrakerSensorDescription(
+                        key=f"{split_obj[0]}_{split_obj[1]}_pressure",
+                        status_key=obj,
+                        name=split_obj[1].replace("_", " ").title() + " Pressure",
+                        value_fn=lambda sensor: sensor.coordinator.data["status"][
+                            sensor.status_key
+                        ]["pressure"],
+                        subscriptions=[(obj, "pressure")],
+                        icon="mdi:gauge",
+                        unit=UnitOfPressure.HPA,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    )
+                    sensors.append(desc)
+
+                if "humidity" in result["status"][obj].keys():
+                    desc = MoonrakerSensorDescription(
+                        key=f"{split_obj[0]}_{split_obj[1]}_humidity",
+                        status_key=obj,
+                        name=split_obj[1].replace("_", " ").title() + " Humidity",
+                        value_fn=lambda sensor: sensor.coordinator.data["status"][
+                            sensor.status_key
+                        ]["humidity"],
+                        subscriptions=[(obj, "humidity")],
+                        icon="mdi:water-percent",
+                        unit=PERCENTAGE,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    )
+                    sensors.append(desc)
+
+                if "gas" in result["status"][obj].keys():
+                    desc = MoonrakerSensorDescription(
+                        key=f"{split_obj[0]}_{split_obj[1]}_gas",
+                        status_key=obj,
+                        name=split_obj[1].replace("_", " ").title() + " Gas",
+                        value_fn=lambda sensor: sensor.coordinator.data["status"][
+                            sensor.status_key
+                        ]["gas"],
+                        subscriptions=[(obj, "gas")],
+                        icon="mdi:eye",
+                        unit=None,
+                        state_class=SensorStateClass.MEASUREMENT,
+                    )
+                    sensors.append(desc)
+
+
         elif split_obj[0] in fan_keys:
             desc = MoonrakerSensorDescription(
                 key=f"{split_obj[0]}_{split_obj[1]}",

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -339,7 +339,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
             desc = MoonrakerSensorDescription(
                 key=f"{split_obj[0]}_{split_obj[1]}",
                 status_key=obj,
-                name=split_obj[1].replace("_", " ").title() + " Temperature",
+                name=split_obj[1].removesuffix("_temp").replace("_", " ").title() + " Temp",
                 value_fn=lambda sensor: sensor.coordinator.data["status"][
                     sensor.status_key
                 ]["temperature"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,6 +120,9 @@ def get_data_fixture():
             },
             "bme280 bme280_temp": {
                 "temperature": 32.43,
+                "pressure": 988.1478719193026,
+                "humidity": 26.783619296566297,
+                "gas": 36351.74625591767,
             },
             "tmc2240 tmc2240_stepper_x_temp": {
                 "temperature": 32.43,


### PR DESCRIPTION
This PR addresses issue #277. I also fixed a typo for `Print Projected Total Duration`. With all the additional sensors added, I opted to append the sensor type to the name of the sensor from Moonraker, including the temperature. While that works better for my BME680 multisensor, I could see why it might be undesirable for other temperature sensors.

Something I've left unaddressed is the precision of the new sensors. I'm new to Home Assistant integrations and I don't do much Python. I'm seeing way too many digits right now. I can manually set it in Home Assistant, but it would be better to set it in the integration.

![image](https://github.com/marcolivierarsenault/moonraker-home-assistant/assets/142754/60450d9f-b615-45ee-8a2c-a48d87ca02d4)
