### PR TITLE
Add support for TMC2240 temperature sensors

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -354,6 +354,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
     temperature_keys = [
         "temperature_sensor",
         "temperature_fan",
+        "tmc2240",
         "bme280",
         "htu21d",
         "lm75",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,9 @@ def get_data_fixture():
             "bme280 bme280_temp": {
                 "temperature": 32.43,
             },
+            "tmc2240 tmc2240_stepper_x_temp": {
+                "temperature": 32.43,
+            },
             "htu21d htu21d_temp": {
                 "temperature": 32.43,
             },
@@ -269,6 +272,7 @@ def get_printer_objects_list_fixture():
             "temperature_fan fan_temp",
             "temperature_host host_temp",
             "bme280 bme280_temp",
+            "tmc2240 tmc2240_stepper_x_temp",
             "htu21d htu21d_temp",
             "lm75 lm75_temp",
             "heater_fan heater_fan",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -91,6 +91,7 @@ async def test_sensor_services_update(hass, get_data):
         ("mainsail_extruder_power", "66"),
         ("mainsail_fan_speed", "51.23"),
         ("mainsail_fan_temp", "32.43"),
+        ("mainsail_tmc2240_stepper_x_temp", "32.43"),
         ("mainsail_bme280_temp", "32.43"),
         ("mainsail_htu21d_temp", "32.43"),
         ("mainsail_lm75_temp", "32.43"),


### PR DESCRIPTION
Thanks a lot for this hass component! This PR adds the temperature readings from tmc2240 drivers.

TMC2240s only expose temperature readings while active, otherwise they will be `null`. I quickly tried this on my HASS instance and the sensor state is `unknown`.

![image](https://github.com/marcolivierarsenault/moonraker-home-assistant/assets/150130755/cea0019e-e4ad-4a54-9912-d6845b846c72)

Once running, they report the correct temperature (I just homed `Z` here)

![image](https://github.com/marcolivierarsenault/moonraker-home-assistant/assets/150130755/91a181b3-80b3-4ddf-bcb9-dcc31ead6695)

and after switching the motor off again the state will return to `unknown`.



```
GET /printer/objects/query?tmc2240%20stepper_x HTTP/1.1
Accept: */*
Accept-Encoding: gzip, deflate
Connection: keep-alive
Host: 192.168.5.187:7125
User-Agent: HTTPie/3.2.1



HTTP/1.1 200 OK
Content-Length: 257
Content-Type: application/json; charset=UTF-8
Date: Fri, 15 Mar 2024 22:16:34 GMT
Etag: "ef4bba874ca3634db7a983d8ff496ae2694a17ab"
Server: TornadoServer/6.4

{
    "result": {
        "eventtime": 26281.896043323,
        "status": {
            "tmc2240 stepper_x": {
                "drv_status": null,
                "hold_current": 0.9998931827716022,
                "mcu_phase_offset": 0,
                "phase_offset_position": 203.59062500000002,
                "run_current": 0.9998931827716022,
                "temperature": null
            }
        }
    }
}
```