### PR TITLE
Add sensors for job queue status and queue count

### DIFF
--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -59,6 +59,7 @@ class METHODS(Enum):
     PRINTER_FIRMWARE_RESTART = "printer.firmware_restart"
     SERVER_FILES_METADATA = "server.files.metadata"
     SERVER_HISTORY_TOTALS = "server.history.totals"
+    SERVER_JOB_QUEUE_STATUS = "server.job_queue.status"
     SERVER_RESTART = "server.restart"
     SERVER_WEBCAMS_LIST = "server.webcams.list"
 

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -586,6 +586,7 @@ async def _queue_updater(coordinator):
     }
 
 async def async_setup_queue_sensors(coordinator, entry, async_add_entities):
+    """Job queue sensors."""
     queue = await coordinator.async_fetch_data(METHODS.SERVER_JOB_QUEUE_STATUS)
     if queue.get("error"):
         return

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -280,8 +280,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
     await async_setup_basic_sensor(coordinator, entry, async_add_entities)
     await async_setup_optional_sensors(coordinator, entry, async_add_entities)
     await async_setup_history_sensors(coordinator, entry, async_add_entities)
-    await async_setup_queue_sensors(coordinator, entry, async_add_entities)
     await async_setup_machine_update_sensors(coordinator, entry, async_add_entities)
+    await async_setup_queue_sensors(coordinator, entry, async_add_entities)
 
 
 async def async_setup_basic_sensor(coordinator, entry, async_add_entities):

--- a/docs/entities/sensors.rst
+++ b/docs/entities/sensors.rst
@@ -97,6 +97,12 @@ Sensors that are added on integration startup.
   * - Total Layer
     - Total number of layer in the current print.
     - From Moonraker API (print_stats, info, total_layer). Make sure your Slicer include it. `Details <https://github.com/marcolivierarsenault/moonraker-home-assistant/issues/112#issuecomment-1505664692>`__
+  * - Queue State
+    - State of the print job queue.
+    - From Moonraker API (ready, loading, starting, paused). `Details <https://moonraker.readthedocs.io/en/latest/web_api/#retrieve-the-job-queue-status>`__
+  * - Jobs in queue
+    - Number of print jobs in the job queue.
+    - From Moonraker API (queued_jobs)
 
 
 History Sensors


### PR DESCRIPTION
This PR adds two new sensors making use of the job queue API.
One sensor is a textual representation of the current job queue status.
The other one, that initially made me think about implementing this, represents the current amount of jobs in the queue. As I programmed an automation that gracefully shuts down my printer and turns its power off, I though that there should be a way to only do that if there are no pending jobs in the printer's queue.

I am unsure about the unit tests - please advise if and how I should add one ore more tests for these sensors.