### PR TITLE
Add some system stats sensors. System Load, MCU Load, Memory Used

### DIFF
--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -7,7 +7,7 @@ from homeassistant.const import Platform
 # Base component constants
 DOMAIN = "moonraker"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 MANIFACTURER = "@marcolivierarsenault"
 
 # Platforms

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -47,6 +47,7 @@ class METHODS(Enum):
     MACHINE_DEVICE_POWER_POST_DEVICE = "machine.device_power.post_device"
     MACHINE_UPDATE_REFRESH = "machine.update.refresh"
     MACHINE_UPDATE_STATUS = "machine.update.status"
+    MACHINE_SYSTEM_INFO = "machine.system_info"
     PRINTER_EMERGENCY_STOP = "printer.emergency_stop"
     PRINTER_INFO = "printer.info"
     PRINTER_GCODE_HELP = "printer.gcode.help"

--- a/custom_components/moonraker/manifest.json
+++ b/custom_components/moonraker/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/marcolivierarsenault/moonraker-home-assistant/issues",
   "loggers": ["moonraker"],
   "requirements": ["moonraker-api==2.0.5"],
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -382,7 +382,33 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                         state_class=SensorStateClass.MEASUREMENT,
                     )
                     sensors.append(desc)
-
+        elif split_obj[0] == "mcu":
+            if len(split_obj) > 1:
+                key = f"{split_obj[0]}_{split_obj[1]}"
+                name = split_obj[1].replace("_", " ").title()
+            else:
+                key = split_obj[0]
+                name = split_obj[0].title()
+            desc = MoonrakerSensorDescription(
+                key=f"{key}_load",
+                status_key=obj,
+                name=f"{name} Load",
+                value_fn=lambda sensor: (
+                        sensor.coordinator.data["status"][sensor.status_key]["last_stats"]["mcu_task_avg"]
+                        + 3 * sensor.coordinator.data["status"][sensor.status_key]["last_stats"]["mcu_task_stddev"]
+                    ) / 0.0025 * 100,
+                subscriptions=[(obj, "last_stats")],
+            )
+            sensors.append(desc)
+            desc = MoonrakerSensorDescription(
+                key=f"{key}_awake",
+                status_key=obj,
+                name=f"{name} Awake",
+                value_fn=lambda sensor: sensor.coordinator.data["status"][sensor.status_key]["last_stats"]["mcu_awake"]
+                    / 5 * 100,
+                subscriptions=[(obj, "last_stats")],
+            )
+            sensors.append(desc)
         elif split_obj[0] in fan_keys:
             desc = MoonrakerSensorDescription(
                 key=f"{split_obj[0]}_{split_obj[1]}",

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -273,8 +273,8 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="sysload",
         name="System Load",
-        value_fn=lambda sensor: sensor.coordinator.data["status"]["system_stats"]["load"],
-        subscriptions=[("system_stats", "load")],
+        value_fn=lambda sensor: sensor.coordinator.data["status"]["system_stats"]["sysload"],
+        subscriptions=[("system_stats", "sysload")],
         icon="mdi:cpu-64-bit",
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -403,7 +403,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
         elif split_obj[0] == "mcu":
             if len(split_obj) > 1:
                 key = f"{split_obj[0]}_{split_obj[1]}"
-                name = split_obj[1].replace("_", " ").title()
+                name = obj.replace("_", " ").title()
             else:
                 key = split_obj[0]
                 name = split_obj[0].title()
@@ -416,6 +416,9 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                         + 3 * sensor.coordinator.data["status"][sensor.status_key]["last_stats"]["mcu_task_stddev"]
                     ) / 0.0025 * 100,
                 subscriptions=[(obj, "last_stats")],
+                icon="mdi:cpu-64-bit",
+                state_class=SensorStateClass.MEASUREMENT,
+                unit=PERCENTAGE,
             )
             sensors.append(desc)
             desc = MoonrakerSensorDescription(
@@ -424,7 +427,10 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                 name=f"{name} Awake",
                 value_fn=lambda sensor: sensor.coordinator.data["status"][sensor.status_key]["last_stats"]["mcu_awake"]
                     / 5 * 100,
+                icon="mdi:cpu-64-bit",
                 subscriptions=[(obj, "last_stats")],
+                state_class=SensorStateClass.MEASUREMENT,
+                unit=PERCENTAGE,
             )
             sensors.append(desc)
         elif split_obj[0] in fan_keys:

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -273,7 +273,9 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
     MoonrakerSensorDescription(
         key="sysload",
         name="System Load",
-        value_fn=lambda sensor: sensor.coordinator.data["status"]["system_stats"]["sysload"],
+        value_fn=lambda sensor: round(
+            sensor.coordinator.data["status"]["system_stats"]["sysload"], 2
+        ),
         subscriptions=[("system_stats", "sysload")],
         icon="mdi:cpu-64-bit",
         state_class=SensorStateClass.MEASUREMENT,
@@ -303,9 +305,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
 async def _machine_system_info_updater(coordinator):
     return {
-        "system_info": (await coordinator.async_fetch_data(
-            METHODS.MACHINE_SYSTEM_INFO
-        ))["system_info"]
+        "system_info": (
+            await coordinator.async_fetch_data(METHODS.MACHINE_SYSTEM_INFO)
+        )["system_info"]
     }
 
 
@@ -413,9 +415,16 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                 status_key=obj,
                 name=f"{name} Load",
                 value_fn=lambda sensor: (
-                        sensor.coordinator.data["status"][sensor.status_key]["last_stats"]["mcu_task_avg"]
-                        + 3 * sensor.coordinator.data["status"][sensor.status_key]["last_stats"]["mcu_task_stddev"]
-                    ) / 0.0025 * 100,
+                    sensor.coordinator.data["status"][sensor.status_key]["last_stats"][
+                        "mcu_task_avg"
+                    ]
+                    + 3
+                    * sensor.coordinator.data["status"][sensor.status_key][
+                        "last_stats"
+                    ]["mcu_task_stddev"]
+                )
+                / 0.0025
+                * 100,
                 subscriptions=[(obj, "last_stats")],
                 icon="mdi:cpu-64-bit",
                 state_class=SensorStateClass.MEASUREMENT,
@@ -426,8 +435,11 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                 key=f"{key}_awake",
                 status_key=obj,
                 name=f"{name} Awake",
-                value_fn=lambda sensor: sensor.coordinator.data["status"][sensor.status_key]["last_stats"]["mcu_awake"]
-                    / 5 * 100,
+                value_fn=lambda sensor: sensor.coordinator.data["status"][
+                    sensor.status_key
+                ]["last_stats"]["mcu_awake"]
+                / 5
+                * 100,
                 icon="mdi:cpu-64-bit",
                 subscriptions=[(obj, "last_stats")],
                 state_class=SensorStateClass.MEASUREMENT,
@@ -485,7 +497,8 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                     (
                         sensor.coordinator.data["status"][sensor.status_key]["power"]
                         or 0.0
-                    ) * 100
+                    )
+                    * 100
                 ),
                 subscriptions=[(obj, "power")],
                 icon="mdi:flash",
@@ -567,7 +580,8 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
                     (
                         sensor.coordinator.data["status"][sensor.status_key]["power"]
                         or 0.0
-                    ) * 100
+                    )
+                    * 100
                 ),
                 subscriptions=[(obj, "power")],
                 icon="mdi:flash",
@@ -644,10 +658,12 @@ async def async_setup_history_sensors(coordinator, entry, async_add_entities):
     await coordinator.async_refresh()
     async_add_entities([MoonrakerSensor(coordinator, entry, desc) for desc in sensors])
 
+
 async def _queue_updater(coordinator):
     return {
         "queue": await coordinator.async_fetch_data(METHODS.SERVER_JOB_QUEUE_STATUS)
     }
+
 
 async def async_setup_queue_sensors(coordinator, entry, async_add_entities):
     """Job queue sensors."""
@@ -661,27 +677,26 @@ async def async_setup_queue_sensors(coordinator, entry, async_add_entities):
         MoonrakerSensorDescription(
             key="queue_state",
             name="Queue State",
-            value_fn=lambda sensor: sensor.coordinator.data["queue"][
-                "queue_state"
-            ],
+            value_fn=lambda sensor: sensor.coordinator.data["queue"]["queue_state"],
             subscriptions=[("queue_state")],
         ),
         MoonrakerSensorDescription(
             key="queue_count",
             name="Jobs in queue",
-            value_fn=lambda sensor: len(sensor.coordinator.data["queue"][
-                "queued_jobs"
-            ]),
+            value_fn=lambda sensor: len(
+                sensor.coordinator.data["queue"]["queued_jobs"]
+            ),
             subscriptions=[("queued_jobs")],
             icon="mdi:numeric",
             unit="Jobs",
             state_class=SensorStateClass.MEASUREMENT,
-        )
+        ),
     ]
 
     coordinator.load_sensor_data(sensors)
     await coordinator.async_refresh()
     async_add_entities([MoonrakerSensor(coordinator, entry, desc) for desc in sensors])
+
 
 async def _machine_update_updater(coordinator):
     return {

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -270,6 +270,14 @@ SENSORS: tuple[MoonrakerSensorDescription, ...] = [
         device_class=SensorDeviceClass.DISTANCE,
         unit=UnitOfLength.MILLIMETERS,
     ),
+    MoonrakerSensorDescription(
+        key="sysload",
+        name="System Load",
+        value_fn=lambda sensor: sensor.coordinator.data["status"]["system_stats"]["load"],
+        subscriptions=[("system_stats", "load")],
+        icon="mdi:cpu-64-bit",
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 ]
 
 

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -822,6 +822,8 @@ def convert_time(time_s):
 
 
 def calculate_memory_used(data):
+    """Calculate memory used."""
+
     if "system_info" not in data:
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,11 @@ def get_data_fixture():
     return {
         "eventtime": 128684.342831779,
         "status": {
+            "system_stats": {
+                "sysload": 0.244140625,
+                "cputime": 384.86964173,
+                "memavail": 1291812,
+            },
             "configfile": {
                 "settings": {
                     "output_pin digital": {
@@ -168,6 +173,13 @@ def get_data_fixture():
             },
             "gcode_move": {
                 "speed_factor": 2.0,
+            },
+            "mcu": {
+                "last_stats": {
+                    "mcu_awake": 0.031,
+                    "mcu_task_avg": 0.000002,
+                    "mcu_task_stddev": 0.000012,
+                },
             },
         },
         "printer.info": {
@@ -376,6 +388,26 @@ def get_machine_update_status_fixture():
     }
 
 
+@pytest.fixture(name="get_machine_system_info")
+def get_machine_system_info_fixture():
+    """Get Machine Update Status fixture."""
+    return {
+        "system_info": {
+            "cpu_info": {
+                "cpu_count": 4,
+                "bits": "64bit",
+                "processor": "aarch64",
+                "cpu_desc": "",
+                "serial_number": "10000000e2e0a55f",
+                "hardware_desc": "",
+                "model": "Raspberry Pi Compute Module 4 Rev 1.1",
+                "total_memory": 1891256,
+                "memory_units": "kB",
+            },
+        }
+    }
+
+
 @pytest.fixture(name="get_default_api_response")
 def get_default_api_response_fixure(
     get_data,
@@ -386,6 +418,7 @@ def get_default_api_response_fixure(
     get_gcode_help,
     get_power_devices,
     get_machine_update_status,
+    get_machine_system_info,
 ):
     """Get all the default fixture returned by moonraker."""
     return {
@@ -397,6 +430,7 @@ def get_default_api_response_fixure(
         **get_gcode_help,
         **get_power_devices,
         **get_machine_update_status,
+        **get_machine_system_info,
     }
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -362,6 +362,35 @@ async def test_no_fan_sensor(hass, get_data, get_printer_objects_list):
     assert state is None
 
 
+async def test_multi_mcu_sensor_data(hass, get_data, get_printer_objects_list):
+    """Test."""
+    get_printer_objects_list["objects"].append("mcu Extruder")
+    get_data["status"]["mcu Extruder"] = {
+        "last_stats": {
+            "mcu_awake": 0.031,
+            "mcu_task_avg": 0.000002,
+            "mcu_task_stddev": 0.000012,
+        },
+    }
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    config_entry.add_to_hass(hass)
+    assert await async_setup_entry(hass, config_entry)
+    await hass.async_block_till_done()
+
+    registry = get_entity_registry(hass)
+
+    assert (
+        registry.async_get_entity_id("sensor", DOMAIN, "test_mcu_Extruder_load")
+        is not None
+    )
+
+    assert (
+        registry.async_get_entity_id("sensor", DOMAIN, "test_mcu_Extruder_awake")
+        is not None
+    )
+
+
 async def test_rounding_fan(hass, get_data):
     """Test."""
     get_data["status"]["fan"]["speed"] = 0.33333333333


### PR DESCRIPTION
Add some system stats sensors.

- System Load
- Memory Used Percent
- MCU Load/Awake

## Relative Graph metrics from fluidd

![image](https://github.com/marcolivierarsenault/moonraker-home-assistant/assets/13523027/729856ab-f24c-439d-92ec-ecd1efbe480c)

- MCU Load/Awake: https://github.com/fluidd-core/fluidd/blob/f3e4ac3c5c795051af26c6d195b6fd768c1e8906/src/store/chart_helpers.ts#L29-L32
- Memory Used Percent: https://github.com/fluidd-core/fluidd/blob/f3e4ac3c5c795051af26c6d195b6fd768c1e8906/src/store/chart_helpers.ts#L80-L86

## HA Results

![image](https://github.com/marcolivierarsenault/moonraker-home-assistant/assets/13523027/4fd2f2f6-1827-4e37-9423-c0fca4efdd69)
