### PR TITLE
add "Reset Totals" button

### DIFF
--- a/custom_components/moonraker/button.py
+++ b/custom_components/moonraker/button.py
@@ -93,6 +93,14 @@ BUTTONS: tuple[MoonrakerButtonDescription, ...] = [
         ),
         icon="mdi:refresh",
     ),
+    MoonrakerButtonDescription(
+        key="reset_totals",
+        name="Reset Totals",
+        press_fn=lambda button: button.coordinator.async_send_data(
+            METHODS.SERVER_HISTORY_RESET_TOTALS
+        ),
+        icon="mdi:history",
+    ),
 ]
 
 

--- a/custom_components/moonraker/button.py
+++ b/custom_components/moonraker/button.py
@@ -96,6 +96,7 @@ BUTTONS: tuple[MoonrakerButtonDescription, ...] = [
     MoonrakerButtonDescription(
         key="reset_totals",
         name="Reset Totals",
+        entity_registry_enabled_default=False,
         press_fn=lambda button: button.coordinator.async_send_data(
             METHODS.SERVER_HISTORY_RESET_TOTALS
         ),

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -62,6 +62,7 @@ class METHODS(Enum):
     PRINTER_FIRMWARE_RESTART = "printer.firmware_restart"
     SERVER_FILES_METADATA = "server.files.metadata"
     SERVER_HISTORY_TOTALS = "server.history.totals"
+    SERVER_HISTORY_RESET_TOTALS = "server.history.reset_totals"
     SERVER_JOB_QUEUE_STATUS = "server.job_queue.status"
     SERVER_RESTART = "server.restart"
     SERVER_WEBCAMS_LIST = "server.webcams.list"

--- a/docs/entities/controls.rst
+++ b/docs/entities/controls.rst
@@ -41,6 +41,9 @@ A series of buttons are available by default. They are:
   * - Printer Switch
     - Power On/Off the printer.
     - From Moonraker API (*machine.device_power.devices*)
+  * - Reset Totals
+    - Reset moonraker statistics. Button is disabled by default.
+    - From Moonraker API (*server.history.reset_totals*)
 
 Macros
 ---------------------------------


### PR DESCRIPTION
Add a "Reset Totals" so we can reset the counters from home assistant.

I use this so it's easier to keep track of how much filament and time I use after each spool change.