### PR TITLE
Lots of changes to the new neopixel support

### DIFF
--- a/custom_components/moonraker/light.py
+++ b/custom_components/moonraker/light.py
@@ -1,10 +1,13 @@
 """Light platform for Moonraker integration."""
+
 import logging
 from dataclasses import dataclass
 
-from homeassistant.components.light import (LightEntity,
-                                            LightEntityDescription,
-                                            ColorMode)
+from homeassistant.components.light import (
+    LightEntity,
+    LightEntityDescription,
+    ColorMode,
+)
 from homeassistant.core import callback
 from homeassistant.util import color
 
@@ -41,7 +44,8 @@ async def async_setup_light(coordinator, entry, async_add_entities):
 
     lights = []
     for obj in object_list["objects"]:
-        if (not obj.startswith("led ")
+        if (
+            not obj.startswith("led ")
             and not obj.startswith("neopixel ")
             and not obj.startswith("dotstar ")
             and not obj.startswith("pca9533 ")
@@ -77,22 +81,19 @@ async def async_setup_light(coordinator, entry, async_add_entities):
         elif led_type == "pca9533":
             color_mode = ColorMode.RGBW
 
-
         desc = MoonrakerLightSensorDescription(
             key=obj,
             sensor_name=obj,
             name=obj.replace("_", " ").title(),
             icon="mdi:led-variant-on",
             subscriptions=[(obj, "color_data")],
-            color_mode=color_mode
+            color_mode=color_mode,
         )
         lights.append(desc)
 
     coordinator.load_sensor_data(lights)
     await coordinator.async_refresh()
-    async_add_entities(
-        [MoonrakerLED(coordinator, entry, desc) for desc in lights]
-    )
+    async_add_entities([MoonrakerLED(coordinator, entry, desc) for desc in lights])
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -128,18 +129,39 @@ class MoonrakerLED(BaseMoonrakerEntity, LightEntity):
         **kwargs,
     ) -> None:
         """Turn on the light."""
+        self._attr_is_on = True
         if rgb_color:
             await self._set_rgbw(*rgb_color, 0)
         else:
             if brightness is None:
                 brightness = 255
-            await self._set_rgbw(brightness, brightness, brightness, brightness)
+                await self._set_rgbw(brightness, brightness, brightness, brightness)
+            else:
+                color_data = self.coordinator.data["status"][self.sensor_name][
+                    "color_data"
+                ][0]
+                color_data[0]
+                multiplier = brightness / (
+                    max(color_data[0], color_data[1], color_data[2], color_data[3])
+                    * 255
+                )
+                await self._set_rgbw(
+                    (color_data[0] * 255 * multiplier),
+                    (color_data[1] * 255 * multiplier),
+                    (color_data[2] * 255 * multiplier),
+                    (color_data[3] * 255 * multiplier),
+                )
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the light."""
+        self._attr_is_on = False
         await self._set_rgbw(0, 0, 0, 0)
 
     async def _set_rgbw(self, r: int, g: int, b: int, w: int) -> None:
+        """Update HA attributes."""
+        self._attr_rgb_color = (r, g, b)
+        self._attr_rgbw_color = (r, g, b, w)
+        self._attr_brightness = max(r, g, b, w)
         """Set native Value."""
         f_r = round(color.brightness_to_value((1, 100), r) / 100, 2)
         f_g = round(color.brightness_to_value((1, 100), g) / 100, 2)
@@ -147,22 +169,36 @@ class MoonrakerLED(BaseMoonrakerEntity, LightEntity):
         f_w = round(color.brightness_to_value((1, 100), w) / 100, 2)
         await self.coordinator.async_send_data(
             METHODS.PRINTER_GCODE_SCRIPT,
-            {"script": f"SET_LED LED=\"{self.led_name}\" RED={f_r} GREEN={f_g} BLUE={f_b} WHITE={f_w} SYNC=0 TRANSMIT=1"},
+            {
+                "script": f'SET_LED LED="{self.led_name}" RED={f_r} GREEN={f_g} BLUE={f_b} WHITE={f_w} SYNC=0 TRANSMIT=1'
+            },
         )
         self._attr_rgbw_color = (r, g, b, w)
         self.async_write_ha_state()
 
     def _set_attributes_from_coordinator(self) -> None:
         color_data = self.coordinator.data["status"][self.sensor_name]["color_data"][0]
-        r = color.value_to_brightness((1, 100), color_data[0] * 100)
-        g = color.value_to_brightness((1, 100), color_data[1] * 100)
-        b = color.value_to_brightness((1, 100), color_data[2] * 100)
-        w = color.value_to_brightness((1, 100), color_data[3] * 100)
+        if color_data[0] != 0:
+            r = color.value_to_brightness((1, 100), color_data[0] * 100)
+        else:
+            r = 0
+        if color_data[1] != 0:
+            g = color.value_to_brightness((1, 100), color_data[1] * 100)
+        else:
+            g = 0
+        if color_data[2] != 0:
+            b = color.value_to_brightness((1, 100), color_data[2] * 100)
+        else:
+            b = 0
+        if color_data[3] != 0:
+            w = color.value_to_brightness((1, 100), color_data[3] * 100)
+        else:
+            w = 0
         self._set_attributes(r, g, b, w)
 
     def _set_attributes(self, r: int, g: int, b: int, w: int) -> None:
         self._attr_is_on = r > 0 or g > 0 or b > 0 or w > 0
-        self._attr_brightness = w
+        self._attr_brightness = max(r, g, b, w)
         self._attr_rgb_color = (r, g, b)
         self._attr_rgbw_color = (r, g, b, w)
 

--- a/custom_components/moonraker/light.py
+++ b/custom_components/moonraker/light.py
@@ -129,14 +129,14 @@ class MoonrakerLED(BaseMoonrakerEntity, LightEntity):
         **kwargs,
     ) -> None:
         """Turn on the light."""
-        self._attr_is_on = True
         if rgb_color:
             await self._set_rgbw(*rgb_color, 0)
         else:
-            if brightness is None:
+            if brightness is None or not self._attr_is_on:
                 brightness = 255
+                self._attr_is_on = True
                 await self._set_rgbw(brightness, brightness, brightness, brightness)
-            else:
+            elif self._attr_is_on:
                 color_data = self.coordinator.data["status"][self.sensor_name][
                     "color_data"
                 ][0]

--- a/custom_components/moonraker/light.py
+++ b/custom_components/moonraker/light.py
@@ -140,7 +140,6 @@ class MoonrakerLED(BaseMoonrakerEntity, LightEntity):
                 color_data = self.coordinator.data["status"][self.sensor_name][
                     "color_data"
                 ][0]
-                color_data[0]
                 multiplier = brightness / (
                     max(color_data[0], color_data[1], color_data[2], color_data[3])
                     * 255

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,7 +224,7 @@ def get_data_fixture():
                 "color_data": [[1.0, 0.5, 0.0, 0.0]],
             },
             "led generic_rgb": {
-                "color_data": [[1.0, 0.5, 0.0, 0.0]],
+                "color_data": [[1.0, 0.5, 1.0, 0.0]],
             },
             "gcode_move": {
                 "speed_factor": 2.0,

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -23,7 +23,7 @@ def bypass_connect_client_fixture():
 # test light on
 @pytest.mark.parametrize(
     "light",
-    [("mainsail_led_chamber"), ("mainsail_neopixel_CAMERA")],
+    [("mainsail_led_chamber")],
 )
 async def test_light_turn_on(hass, light, get_default_api_response):
     """Test."""
@@ -33,8 +33,8 @@ async def test_light_turn_on(hass, light, get_default_api_response):
     await hass.async_block_till_done()
 
     with patch(
-            "moonraker_api.MoonrakerClient.call_method",
-            return_value={**get_default_api_response},
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_default_api_response},
     ) as mock_api:
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -48,7 +48,39 @@ async def test_light_turn_on(hass, light, get_default_api_response):
 
         mock_api.assert_any_call(
             METHODS.PRINTER_GCODE_SCRIPT.value,
-            script=f"SET_LED LED=\"{light.split('_')[2]}\" RED=1.0 GREEN=1.0 BLUE=1.0 WHITE=1.0 SYNC=0 TRANSMIT=1",
+            script=f'SET_LED LED="{light.split("_")[2]}" RED=0.0 GREEN=0.0 BLUE=0.0 WHITE=1.0 SYNC=0 TRANSMIT=1',
+        )
+
+
+# test dim
+@pytest.mark.parametrize(
+    "light",
+    [("mainsail_neopixel_CAMERA")],
+)
+async def test_light_dim(hass, light, get_default_api_response):
+    """Test."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_default_api_response},
+    ) as mock_api:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: f"light.{light}",
+                "brightness": 128,
+            },
+            blocking=True,
+        )
+
+        mock_api.assert_any_call(
+            METHODS.PRINTER_GCODE_SCRIPT.value,
+            script=f'SET_LED LED="{light.split("_")[2]}" RED=0.5 GREEN=0.25 BLUE=0.0 WHITE=0.0 SYNC=0 TRANSMIT=1',
         )
 
 
@@ -65,8 +97,8 @@ async def test_light_turn_on_default(hass, light, get_default_api_response):
     await hass.async_block_till_done()
 
     with patch(
-            "moonraker_api.MoonrakerClient.call_method",
-            return_value={**get_default_api_response},
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_default_api_response},
     ) as mock_api:
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -79,7 +111,7 @@ async def test_light_turn_on_default(hass, light, get_default_api_response):
 
         mock_api.assert_any_call(
             METHODS.PRINTER_GCODE_SCRIPT.value,
-            script=f"SET_LED LED=\"{light.split('_')[2]}\" RED=1.0 GREEN=1.0 BLUE=1.0 WHITE=1.0 SYNC=0 TRANSMIT=1",
+            script=f'SET_LED LED="{light.split("_")[2]}" RED=1.0 GREEN=1.0 BLUE=1.0 WHITE=1.0 SYNC=0 TRANSMIT=1',
         )
 
 
@@ -96,8 +128,8 @@ async def test_light_turn_on_rgb(hass, light, get_default_api_response):
     await hass.async_block_till_done()
 
     with patch(
-            "moonraker_api.MoonrakerClient.call_method",
-            return_value={**get_default_api_response},
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_default_api_response},
     ) as mock_api:
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -111,7 +143,7 @@ async def test_light_turn_on_rgb(hass, light, get_default_api_response):
 
         mock_api.assert_any_call(
             METHODS.PRINTER_GCODE_SCRIPT.value,
-            script=f"SET_LED LED=\"{light.split('_')[2]}\" RED=1.0 GREEN=0.0 BLUE=0.5 WHITE=0.0 SYNC=0 TRANSMIT=1",
+            script=f'SET_LED LED="{light.split("_")[2]}" RED=1.0 GREEN=0.0 BLUE=0.5 WHITE=0.0 SYNC=0 TRANSMIT=1',
         )
 
 
@@ -128,8 +160,8 @@ async def test_light_turn_off(hass, light, get_default_api_response):
     await hass.async_block_till_done()
 
     with patch(
-            "moonraker_api.MoonrakerClient.call_method",
-            return_value={**get_default_api_response},
+        "moonraker_api.MoonrakerClient.call_method",
+        return_value={**get_default_api_response},
     ) as mock_api:
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -142,5 +174,5 @@ async def test_light_turn_off(hass, light, get_default_api_response):
 
         mock_api.assert_any_call(
             METHODS.PRINTER_GCODE_SCRIPT.value,
-            script=f"SET_LED LED=\"{light.split('_')[2]}\" RED=0.0 GREEN=0.0 BLUE=0.0 WHITE=0.0 SYNC=0 TRANSMIT=1",
+            script=f'SET_LED LED="{light.split("_")[2]}" RED=0.0 GREEN=0.0 BLUE=0.0 WHITE=0.0 SYNC=0 TRANSMIT=1',
         )


### PR DESCRIPTION
- Set attributes to update locally when making changes.  This makes the interface more responsive instead of waiting for the state to refresh.  Changes are now reflected instantly.

- Implement dimming with colors.  Previously, dimming would revert to white only, regardless of what the separate rgbw values were.  Now, it will scale with whatever the brightest value is, so a value of 128,50,5,0 at 50% will scale to 255,100,10,0 at 100%.

- Fix brightness calculation.  Brightness used to be calculated based on the white value.  Now, it's based on the brightest of rgbw.

- Fix on off functionality.  There was a bug where a brightness value of 0 could never be set, even when the led was off.  Now, there is a check to see if the light is off before converting the decimal value of brightness to a 255 based value.