### PR TITLE
Add "Start Print from Queue" button 

### DIFF
--- a/custom_components/moonraker/button.py
+++ b/custom_components/moonraker/button.py
@@ -102,6 +102,14 @@ BUTTONS: tuple[MoonrakerButtonDescription, ...] = [
         ),
         icon="mdi:history",
     ),
+    MoonrakerButtonDescription(
+        key="start_print_from_queue",
+        name="Start Print from Queue",
+        press_fn=lambda button: button.coordinator.async_send_data(
+            METHODS.SERVER_JOB_QUEUE_START
+        ),
+        icon="mdi:play-circle",
+    ),
 ]
 
 

--- a/custom_components/moonraker/button.py
+++ b/custom_components/moonraker/button.py
@@ -1,9 +1,9 @@
 """Button platform for Moonraker integration."""
+
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from homeassistant.components.button import (ButtonEntity,
-                                             ButtonEntityDescription)
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 
 from .const import DOMAIN, METHODS
 from .entity import BaseMoonrakerEntity
@@ -108,7 +108,7 @@ BUTTONS: tuple[MoonrakerButtonDescription, ...] = [
         press_fn=lambda button: button.coordinator.async_send_data(
             METHODS.SERVER_JOB_QUEUE_START
         ),
-        icon="mdi:play-circle",
+        icon="mdi:playlist-play",
     ),
 ]
 

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -66,6 +66,7 @@ class METHODS(Enum):
     SERVER_HISTORY_TOTALS = "server.history.totals"
     SERVER_HISTORY_RESET_TOTALS = "server.history.reset_totals"
     SERVER_JOB_QUEUE_STATUS = "server.job_queue.status"
+    SERVER_JOB_QUEUE_START = "server.job_queue.start"
     SERVER_RESTART = "server.restart"
     SERVER_WEBCAMS_LIST = "server.webcams.list"
 

--- a/docs/entities/controls.rst
+++ b/docs/entities/controls.rst
@@ -26,6 +26,9 @@ A series of buttons are available by default. They are:
   * - Cancel Print
     - Cancel current print.
     - From Moonraker API (*printer.print.cancel*)
+  * - Start Print from Queue
+    - Start the next print job in the queue.
+    - From Moonraker API (*server.job_queue.start*)
   * - Server Restart
     - Restart Klipper software.
     - From Moonraker API (*server.restart*)

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -32,6 +32,7 @@ def bypass_connect_client_fixture():
         ("mainsail_resume_print", METHODS.PRINTER_PRINT_RESUME.value),
         ("mainsail_server_restart", METHODS.SERVER_RESTART.value),
         ("mainsail_cancel_print", METHODS.PRINTER_PRINT_CANCEL.value),
+        ("mainsail_start_print_queue", METHODS.SERVER_JOB_QUEUE_START.value),
     ],
 )
 async def test_buttons(hass, button, method):

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -32,7 +32,7 @@ def bypass_connect_client_fixture():
         ("mainsail_resume_print", METHODS.PRINTER_PRINT_RESUME.value),
         ("mainsail_server_restart", METHODS.SERVER_RESTART.value),
         ("mainsail_cancel_print", METHODS.PRINTER_PRINT_CANCEL.value),
-        ("mainsail_start_print_queue", METHODS.SERVER_JOB_QUEUE_START.value),
+        ("mainsail_start_print_from_queue", METHODS.SERVER_JOB_QUEUE_START.value),
     ],
 )
 async def test_buttons(hass, button, method):


### PR DESCRIPTION
This PR introduces a new button entity allowing users to start a print job from the job queue. The button leverages the Moonraker API's `server.job_queue.start` method to initiate the next job in the queue.

---

### **Changes Made**

   - Added a new button entity named **"Start Print from Queue"**.
   - Icon: `mdi:playlist-play` 
   - API Method: `server.job_queue.start`.
   - Added the new button to the parameterized test cases in `tests/test_button.py`.

---

Let me know if further adjustments are needed!