### PR TITLE
close connection on unauthorized

### DIFF
--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -101,6 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     except Exception as exc:
         _LOGGER.warning("Cannot configure moonraker instance")
+        await api.stop()
         raise ConfigEntryNotReady(f"Error connecting to {url}:{port}") from exc
 
     coordinator = MoonrakerDataUpdateCoordinator(


### PR DESCRIPTION
addressing #517 


before 
```
2025-04-20 13:35:02,734 [websockets.py:prepare()] - Websocket Failed Authentication: HTTP 401: Unauthorized (Unauthorized)
2025-04-20 13:35:02,736 [application.py:log_request()] - 101 GET /websocket (192.168.2.100) [No User] 4.42ms
2025-04-20 13:35:02,737 [websockets.py:open()] - Websocket Opened: ID: 4102628464, Proxied: False, User Agent: HomeAssistant/2025.4.2 aiohttp/3.11.16 Python/3.13, Host Name: 192.168.2.30
2025-04-20 13:35:02,738 [common.py:build_error()] - JSON-RPC Request Error - Requested Method: printer.info, Code: -32602, Message: Unauthorized
2025-04-20 13:35:13,079 [websockets.py:prepare()] - Websocket Failed Authentication: HTTP 401: Unauthorized (Unauthorized)
2025-04-20 13:35:13,081 [application.py:log_request()] - 101 GET /websocket (192.168.2.100) [No User] 2.22ms
2025-04-20 13:35:13,081 [websockets.py:open()] - Websocket Opened: ID: 4102630640, Proxied: False, User Agent: HomeAssistant/2025.4.2 aiohttp/3.11.16 Python/3.13, Host Name: 192.168.2.30
2025-04-20 13:35:13,082 [common.py:build_error()] - JSON-RPC Request Error - Requested Method: printer.info, Code: -32602, Message: Unauthorized
```

after
```
2025-04-20 14:04:32,410 [websockets.py:prepare()] - Websocket Failed Authentication: HTTP 401: Unauthorized (Unauthorized)
2025-04-20 14:04:32,412 [application.py:log_request()] - 101 GET /websocket (192.168.2.90) [No User] 2.52ms
2025-04-20 14:04:32,412 [websockets.py:open()] - Websocket Opened: ID: 4120554800, Proxied: False, User Agent: HomeAssistant/2025.4.3 aiohttp/3.11.16 Python/3.13, Host Name: 192.168.2.30
2025-04-20 14:04:32,417 [common.py:build_error()] - JSON-RPC Request Error - Requested Method: printer.info, Code: -32602, Message: Unauthorized
2025-04-20 14:04:32,422 [websockets.py:on_close()] - Websocket Closed: ID: 4120554800 Close Code: 1000, Close Reason: None, Pong Time Elapsed: 0.01
2025-04-20 14:04:32,665 [websockets.py:prepare()] - Websocket Failed Authentication: HTTP 401: Unauthorized (Unauthorized)
2025-04-20 14:04:32,667 [application.py:log_request()] - 101 GET /websocket (192.168.2.90) [No User] 2.47ms
2025-04-20 14:04:32,667 [websockets.py:open()] - Websocket Opened: ID: 4101991824, Proxied: False, User Agent: HomeAssistant/2025.4.3 aiohttp/3.11.16 Python/3.13, Host Name: 192.168.2.30
2025-04-20 14:04:32,735 [common.py:build_error()] - JSON-RPC Request Error - Requested Method: printer.info, Code: -32602, Message: Unauthorized
2025-04-20 14:04:32,999 [websockets.py:on_close()] - Websocket Closed: ID: 4101991824 Close Code: 1000, Close Reason: None, Pong Time Elapsed: 0.33
```