### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: "ubuntu-latest"
@@ -44,6 +47,8 @@ jobs:
   tests:
     runs-on: "ubuntu-latest"
     name: Run tests
+    permissions:
+      contents: write
     steps:
       - name: Check out code from GitHub
         uses: "actions/checkout@v4"


### PR DESCRIPTION
Potential fix for [https://github.com/marcolivierarsenault/moonraker-home-assistant/security/code-scanning/4](https://github.com/marcolivierarsenault/moonraker-home-assistant/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for each job. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for all jobs to allow access to the repository's contents.
- `contents: write` for the `tests` job to upload coverage reports to Codecov.

The `permissions` block will be added at the root level for jobs that only require `contents: read`, and job-specific permissions will be added for the `tests` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
