### PR TITLE
Add temperature_fan target control

### DIFF
--- a/custom_components/moonraker/number.py
+++ b/custom_components/moonraker/number.py
@@ -26,7 +26,8 @@ class MoonrakerNumberSensorDescription(NumberEntityDescription):
     icon: str | None = None
     unit: str | None = None
     update_code: str | None = None
-    max_value: int | None = None
+    max_value: float | None = None
+    min_value: float | None = None
     device_class: NumberDeviceClass | None = None
     status_key: str | None = None
 
@@ -45,6 +46,12 @@ async def async_setup_temperature_target(coordinator, entry, async_add_entities)
     """Set optional temp target."""
 
     sensors = []
+
+    config_query = {OBJ: {"configfile": ["settings"]}}
+    config_response = await coordinator.async_fetch_data(
+        METHODS.PRINTER_OBJECTS_QUERY, config_query, quiet=True
+    )
+    config_settings = config_response["status"]["configfile"].get("settings", {})
 
     object_list = await coordinator.async_fetch_data(METHODS.PRINTER_OBJECTS_LIST)
     for obj in object_list["objects"]:
@@ -79,6 +86,41 @@ async def async_setup_temperature_target(coordinator, entry, async_add_entities)
                 device_class=NumberDeviceClass.TEMPERATURE,
             )
             sensors.append(desc)
+
+        elif obj.startswith("temperature_fan"):
+            object_type, _, object_name = obj.partition(" ")
+            fan_name = object_name or object_type
+            fan_key = fan_name.replace(" ", "_")
+            display_name = fan_name.replace("_", " ").title()
+
+            settings = config_settings.get(obj)
+            if settings is None:
+                lower_obj = obj.lower()
+                settings = config_settings.get(lower_obj)
+            if settings is None:
+                settings = {}
+
+            max_temp = settings.get("max_temp")
+            min_temp = settings.get("min_temp")
+
+            max_value = float(max_temp) if max_temp is not None else 100.0
+            min_value = float(min_temp) if min_temp is not None else 0.0
+
+            desc = MoonrakerNumberSensorDescription(
+                key=f"{object_type}_{fan_key}_target_control",
+                sensor_name=obj,
+                name=f"{display_name} Target",
+                status_key="target",
+                subscriptions=[(obj, "target")],
+                icon="mdi:thermometer",
+                unit=UnitOfTemperature.CELSIUS,
+                update_code=f"SET_TEMPERATURE_FAN_TARGET FAN={fan_name} TARGET=",
+                max_value=max_value,
+                min_value=min_value,
+                device_class=NumberDeviceClass.TEMPERATURE,
+            )
+            sensors.append(desc)
+            coordinator.add_query_objects(obj, "target")
 
     coordinator.load_sensor_data(sensors)
     await coordinator.async_refresh()
@@ -239,7 +281,16 @@ class MoonrakerNumber(BaseMoonrakerEntity, NumberEntity):
         self._attr_name = description.name
         self._attr_has_entity_name = True
         self._attr_icon = description.icon
-        self._attr_native_max_value = description.max_value
+        self._attr_native_max_value = (
+            float(description.max_value)
+            if description.max_value is not None
+            else None
+        )
+        self._attr_native_min_value = (
+            float(description.min_value)
+            if description.min_value is not None
+            else 0.0
+        )
         self._attr_device_class = description.device_class
         self._attr_native_unit_of_measurement = description.unit
         self.update_string = description.update_code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,14 @@ def get_data_fixture():
                     "output_pin capitalized": {
                         "pwm": True,
                     },
+                    "temperature_fan fan_temp": {
+                        "max_temp": 70.0,
+                        "min_temp": 10.0,
+                    },
+                    "temperature_fan fan_case": {
+                        "max_temp": 65.0,
+                        "min_temp": 5.0,
+                    },
                     "led chamber": {
                         "white_pin": "PA1",
                         "red_pin": "PA2",
@@ -143,6 +151,15 @@ def get_data_fixture():
             },
             "temperature_fan fan_temp": {
                 "temperature": 32.43,
+                "target": 35.0,
+            },
+            "temperature_fan FAN_CASE": {
+                "temperature": 34.0,
+                "target": 40.0,
+            },
+            "temperature_fan missing_config": {
+                "temperature": 28.5,
+                "target": 33.0,
             },
             "fan_generic nevermore_fan": {
                 "speed": 0.1234,
@@ -438,6 +455,8 @@ def get_printer_objects_list_fixture():
             "extruder",
             "extruder1",
             "temperature_fan fan_temp",
+            "temperature_fan FAN_CASE",
+            "temperature_fan missing_config",
             "temperature_host host_temp",
             "bme280 bme280_temp",
             "tmc2240 tmc2240_stepper_x_temp",


### PR DESCRIPTION
## Summary
- expose temperature_fan targets as sensors alongside existing readings
- add number entities for temperature_fan targets to allow adjustments from HA
- extend fixtures and tests to cover the new entities

## Testing
- pytest tests/test_number.py
- pytest tests/test_sensor.py

Fixes #532