### PR TITLE
Fix idle timeout enum mapping for Anycubic complete state

### DIFF
--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -164,10 +164,22 @@ def test_idle_timeout_state_handles_missing():
     assert format_idle_timeout_state(data) is None
 
 
-def test_idle_timeout_state_non_string_passthrough():
-    """format_idle_timeout_state returns non-string state unchanged."""
+def test_idle_timeout_state_non_string_returns_none():
+    """format_idle_timeout_state returns None for non-string states."""
     data = {"status": {"idle_timeout": {"state": 5}}}
-    assert format_idle_timeout_state(data) == 5
+    assert format_idle_timeout_state(data) is None
+
+
+def test_idle_timeout_state_unknown_returns_none():
+    """format_idle_timeout_state returns None for unsupported states."""
+    data = {"status": {"idle_timeout": {"state": "mystery_mode"}}}
+    assert format_idle_timeout_state(data) is None
+
+
+def test_idle_timeout_state_blank_returns_none():
+    """format_idle_timeout_state returns None for blank values."""
+    data = {"status": {"idle_timeout": {"state": "   "}}}
+    assert format_idle_timeout_state(data) is None
 
 
 # test all sensors


### PR DESCRIPTION
## Summary
- normalize idle_timeout state values to a fixed enum set and return None for unsupported values
- reuse a shared options list for the idle timeout sensor to avoid enum validation errors
- add tests for non-string/blank/unknown idle timeout values

## Testing
- not run (pre-commit hooks ran on commit)

Fixes #634