### PR TITLE
Display humidity for all possible klipper sensors. Prevent BME, SHT and LM75 sensors from creating a temperature entity twice.

### DIFF
--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -392,7 +392,7 @@ async def async_setup_optional_sensors(coordinator, entry, async_add_entities):
         "sht3x",
     ]
     environmental_keys = [
-        "bme280", 
+        "bme280",
         "htu21d",
         "aht10",
         "sht3x",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,15 +191,16 @@ def get_data_fixture():
             },
             "bme280 bme280_temp": {
                 "temperature": 32.43,
-                "pressure": 988.1478719193026,
+                "pressure": 988.147871919303,
                 "humidity": 26.7836192965663,
-                "gas": 36351.74625591767,
+                "gas": 36351.7462559177,
             },
             "tmc2240 tmc2240_stepper_x_temp": {
                 "temperature": 32.43,
             },
             "htu21d htu21d_temp": {
                 "temperature": 32.43,
+                "humidity": 55.0,
             },
             "lm75 lm75_temp": {
                 "temperature": 32.43,


### PR DESCRIPTION
**Background:**

The EMU Multi material unit is using AHT20 temperature and humidity sensors / and / or BME280 sensors. However, the current integration to HA only reports humidity if originating from a BME280 sensor, although others are capable of (and are) reporting humidity. In addition, I had noticed a bug where the temperature entity was created twice when using the BME280 sensor.

**Expose humidity for all capable sensor types**

Currently the integration only creates humidity entities for bme280 objects, even though Klipper/Moonraker expose humidity for other environmental sensors (e.g. AHT10/AHT20, HTU21D, SHT3X).

This PR extends environmental sensor support to expose humidity (and other optional fields where available) for all Moonraker objects that report them.

**Fix duplicate temperature entities**

At the moment, temperature entities can be duplicated when the same physical sensor is represented both as:
temperature_sensor <name> (generic), and <module> <name> (e.g. bme280 <name>, aht10 <name>)

This PR deduplicates temperature entities by preferring the generic temperature_sensor <name> reading when both exist, while still exposing environmental extras (humidity/pressure/gas) from the module object.

**Result**
1. Humidity entities appear in Home Assistant for all supported humidity-capable sensors.
2. Duplicate temperature entities are avoided for sensors that are exposed through both generic and module-specific objects

Below you can see the AHT sensor now successfully reporting its humidity value, along side a set of BME280 sensors
![image](https://github.com/user-attachments/assets/b52a27a3-d366-478b-8c48-4230a4c153eb)
