### PR TITLE
Feature/u1 filament info

### DIFF
--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -39,6 +39,18 @@ OBJ = "objects"
 # API timeout
 TIMEOUT = 10
 
+# U1 Custom Filament Attributes
+U1_PRINT_TASK_CONFIG = "print_task_config"
+U1_FILAMENT_ATTRIBUTES = [
+    "filament_color_rgba",
+    "filament_vendor",
+    "filament_type",
+    "filament_sub_type",
+    "filament_official",
+    "filament_sku",
+    "filament_edit",
+    "filament_soft",
+]
 
 class METHODS(Enum):
     """API methods."""

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -840,7 +840,7 @@ async def _spoolman_updater(coordinator):
 async def async_setup_spoolman_sensors(coordinator, entry, async_add_entities):
     """Spoolman sensors."""
     spoolman = await coordinator.async_fetch_data(METHODS.SERVER_SPOOLMAN_ID)
-    if spoolman.get("error"):
+    if spoolman.get("error") or "spoolman_connected" not in spoolman:
         return
 
     coordinator.add_data_updater(_spoolman_updater)

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -21,7 +21,15 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 
-from .const import DOMAIN, METHODS, OBJ, PRINTERSTATES, PRINTSTATES
+from .const import (
+    DOMAIN,
+    METHODS,
+    OBJ,
+    PRINTERSTATES,
+    PRINTSTATES,
+    U1_PRINT_TASK_CONFIG,
+    U1_FILAMENT_ATTRIBUTES,
+)
 from .entity import BaseMoonrakerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,6 +58,13 @@ class MoonrakerSensorDescription(SensorEntityDescription):
     unit: str | None = None
     device_class: str | None = None
     subscriptions: list | None = None
+
+
+@dataclass(frozen=True)
+class U1ExtruderFilamentSensorDescription(MoonrakerSensorDescription):
+    """Class describing U1 filament color sensor, with an additional extra_state_fn."""
+
+    extra_state_fn: Callable = lambda sensor: None
 
 
 SENSORS: tuple[MoonrakerSensorDescription, ...] = (
@@ -356,6 +371,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     await async_setup_machine_update_sensors(coordinator, entry, async_add_entities)
     await async_setup_queue_sensors(coordinator, entry, async_add_entities)
     await async_setup_spoolman_sensors(coordinator, entry, async_add_entities)
+    await async_setup_u1_sensors(coordinator, entry, async_add_entities)
 
 
 async def _machine_system_info_updater(coordinator):
@@ -859,6 +875,59 @@ async def async_setup_spoolman_sensors(coordinator, entry, async_add_entities):
     async_add_entities([MoonrakerSensor(coordinator, entry, desc) for desc in sensors])
 
 
+async def _u1_updater(coordinator):
+    return {
+        U1_PRINT_TASK_CONFIG: (
+            await coordinator._async_fetch_data(
+                METHODS.PRINTER_OBJECTS_QUERY,
+                {OBJ: {U1_PRINT_TASK_CONFIG: U1_FILAMENT_ATTRIBUTES}},
+            )
+        )["status"][U1_PRINT_TASK_CONFIG]
+    }
+
+
+def create_u1_filament_sensor_description(extruder_index):
+    """Create a U1 filament sensor description for the given extruder index."""
+    return U1ExtruderFilamentSensorDescription(
+        key=f"e{extruder_index}_filament_info",
+        name=f"E{extruder_index} Filament Info",
+        value_fn=lambda sensor: f"#{sensor.coordinator.data[U1_PRINT_TASK_CONFIG][
+            'filament_color_rgba'
+        ][extruder_index]}",
+        extra_state_fn=lambda sensor: {
+            field.replace("filament_", ""): sensor.coordinator.data[
+                U1_PRINT_TASK_CONFIG
+            ][field][extruder_index]
+            for field in U1_FILAMENT_ATTRIBUTES
+        },
+        subscriptions=U1_FILAMENT_ATTRIBUTES,
+        icon="mdi:format-color-highlight",
+    )
+
+
+async def async_setup_u1_sensors(coordinator, entry, async_add_entities):
+    """U1 Extruder Filament Info sensors."""
+    u1_print_task_query = await coordinator._async_fetch_data(
+        METHODS.PRINTER_OBJECTS_QUERY,
+        {OBJ: {U1_PRINT_TASK_CONFIG: U1_FILAMENT_ATTRIBUTES}},
+    )
+    if (
+        U1_PRINT_TASK_CONFIG not in u1_print_task_query["status"]
+        or not u1_print_task_query["status"][U1_PRINT_TASK_CONFIG]
+    ):
+        return
+
+    coordinator.add_data_updater(_u1_updater)
+
+    sensors = [create_u1_filament_sensor_description(i) for i in range(4)]
+
+    coordinator.load_sensor_data(sensors)
+    await coordinator.async_refresh()
+    async_add_entities(
+        [U1ExtruderFilamentSensor(coordinator, entry, desc) for desc in sensors]
+    )
+
+
 async def _machine_update_updater(coordinator):
     return {
         "machine_update": await coordinator.async_fetch_data(
@@ -949,6 +1018,23 @@ class MoonrakerSensor(BaseMoonrakerEntity, SensorEntity):
         ):
             return "" if isinstance(value, str) else 0.0
         return value
+
+
+class U1ExtruderFilamentSensor(MoonrakerSensor):
+    """U1 Extruder Filament Sensor with extra attributes for filament details."""
+
+    def __init__(self, coordinator, entry, description):
+        """Init."""
+        super().__init__(coordinator, entry, description)
+        self._attr_extra_state_attributes = self.entity_description.extra_state_fn(self)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        super()._handle_coordinator_update()
+        self._attr_extra_state_attributes.update(
+            self.entity_description.extra_state_fn(self)
+        )
 
 
 def calculate_print_speed(data):

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -900,7 +900,7 @@ def create_u1_filament_sensor_description(extruder_index):
             ][field][extruder_index]
             for field in U1_FILAMENT_ATTRIBUTES
         },
-        subscriptions=U1_FILAMENT_ATTRIBUTES,
+        subscriptions=[],
         icon="mdi:format-color-highlight",
     )
 
@@ -912,6 +912,8 @@ async def async_setup_u1_sensors(coordinator, entry, async_add_entities):
         {OBJ: {U1_PRINT_TASK_CONFIG: U1_FILAMENT_ATTRIBUTES}},
     )
     if (
+        u1_print_task_query is None or
+        "status" not in u1_print_task_query or
         U1_PRINT_TASK_CONFIG not in u1_print_task_query["status"]
         or not u1_print_task_query["status"][U1_PRINT_TASK_CONFIG]
     ):
@@ -1031,10 +1033,10 @@ class U1ExtruderFilamentSensor(MoonrakerSensor):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        super()._handle_coordinator_update()
         self._attr_extra_state_attributes.update(
             self.entity_description.extra_state_fn(self)
         )
+        super()._handle_coordinator_update()
 
 
 def calculate_print_speed(data):

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -886,26 +886,6 @@ async def _u1_updater(coordinator):
     }
 
 
-def create_u1_filament_sensor_description(extruder_index):
-    """Create a U1 filament sensor description for the given extruder index."""
-    return U1ExtruderFilamentSensorDescription(
-        key=f"e{extruder_index}_filament_info",
-        name=f"E{extruder_index} Filament Info",
-        value_fn=lambda sensor: f"#{sensor.coordinator.data[U1_PRINT_TASK_CONFIG][
-            'filament_color_rgba'
-        ][extruder_index]}",
-        extra_state_fn=lambda sensor: {
-            field.replace("filament_", ""): sensor.coordinator.data[
-                U1_PRINT_TASK_CONFIG
-            ][field][extruder_index]
-            for field in U1_FILAMENT_ATTRIBUTES
-            if sensor.coordinator.data[U1_PRINT_TASK_CONFIG][field] # ensure to add only fields that are available
-        },
-        subscriptions=[],
-        icon="mdi:format-color-highlight",
-    )
-
-
 async def async_setup_u1_sensors(coordinator, entry, async_add_entities):
     """U1 Extruder Filament Info sensors."""
     u1_print_task_query = await coordinator._async_fetch_data(
@@ -928,6 +908,26 @@ async def async_setup_u1_sensors(coordinator, entry, async_add_entities):
     await coordinator.async_refresh()
     async_add_entities(
         [U1ExtruderFilamentSensor(coordinator, entry, desc) for desc in sensors]
+    )
+
+
+def create_u1_filament_sensor_description(extruder_index):
+    """Create a U1 filament sensor description for the given extruder index."""
+    return U1ExtruderFilamentSensorDescription(
+        key=f"e{extruder_index}_filament_info",
+        name=f"E{extruder_index} Filament Info",
+        value_fn=lambda sensor: f"#{sensor.coordinator.data[U1_PRINT_TASK_CONFIG][
+            'filament_color_rgba'
+        ][extruder_index]}",
+        extra_state_fn=lambda sensor: {
+            field.replace("filament_", ""): sensor.coordinator.data[
+                U1_PRINT_TASK_CONFIG
+            ][field][extruder_index]
+            for field in U1_FILAMENT_ATTRIBUTES
+            if sensor.coordinator.data[U1_PRINT_TASK_CONFIG][field] # ensure to add only fields that are available
+        },
+        subscriptions=[],
+        icon="mdi:format-color-highlight",
     )
 
 

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -899,6 +899,7 @@ def create_u1_filament_sensor_description(extruder_index):
                 U1_PRINT_TASK_CONFIG
             ][field][extruder_index]
             for field in U1_FILAMENT_ATTRIBUTES
+            if sensor.coordinator.data[U1_PRINT_TASK_CONFIG][field] # ensure to add only fields that are available
         },
         subscriptions=[],
         icon="mdi:format-color-highlight",
@@ -911,13 +912,13 @@ async def async_setup_u1_sensors(coordinator, entry, async_add_entities):
         METHODS.PRINTER_OBJECTS_QUERY,
         {OBJ: {U1_PRINT_TASK_CONFIG: U1_FILAMENT_ATTRIBUTES}},
     )
-    if (
-        u1_print_task_query is None or
-        "status" not in u1_print_task_query or
-        U1_PRINT_TASK_CONFIG not in u1_print_task_query["status"]
-        or not u1_print_task_query["status"][U1_PRINT_TASK_CONFIG]
-    ):
+
+    # If the object isn't supported the API will still respond with {"status": {U1_PRINT_TASK_CONFIG: {}}}
+    # to make sure the sensor can be created ensure that at least `filament_color_rgba` is available and has four entires
+    if len(u1_print_task_query.get("status", {}).get(U1_PRINT_TASK_CONFIG, {}).get("filament_color_rgba", [])) != 4:
+        _LOGGER.debug("`%s` is not available, don't setup U1 Filament Sensors", U1_PRINT_TASK_CONFIG)
         return
+
 
     coordinator.add_data_updater(_u1_updater)
 

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -924,9 +924,7 @@ def create_u1_filament_sensor_description(extruder_index):
     return U1ExtruderFilamentSensorDescription(
         key=f"e{extruder_index}_filament_info",
         name=f"E{extruder_index} Filament Info",
-        value_fn=lambda sensor: f"#{sensor.coordinator.data[U1_PRINT_TASK_CONFIG][
-            'filament_color_rgba'
-        ][extruder_index]}",
+        value_fn=lambda sensor: f"#{sensor.coordinator.data[U1_PRINT_TASK_CONFIG]['filament_color_rgba'][extruder_index]}",
         extra_state_fn=lambda sensor: {
             field.replace("filament_", ""): sensor.coordinator.data[
                 U1_PRINT_TASK_CONFIG

--- a/custom_components/moonraker/sensor.py
+++ b/custom_components/moonraker/sensor.py
@@ -893,9 +893,16 @@ async def async_setup_u1_sensors(coordinator, entry, async_add_entities):
         {OBJ: {U1_PRINT_TASK_CONFIG: U1_FILAMENT_ATTRIBUTES}},
     )
 
+    filament_colors = (
+        u1_print_task_query.get("status", {})
+        .get(U1_PRINT_TASK_CONFIG, {})
+        .get("filament_color_rgba")
+        or []
+    )
+
     # If the object isn't supported the API will still respond with {"status": {U1_PRINT_TASK_CONFIG: {}}}
     # to make sure the sensor can be created ensure that at least `filament_color_rgba` is available and has four entires
-    if len(u1_print_task_query.get("status", {}).get(U1_PRINT_TASK_CONFIG, {}).get("filament_color_rgba", [])) != 4:
+    if len(filament_colors) != 4:
         _LOGGER.debug("`%s` is not available, don't setup U1 Filament Sensors", U1_PRINT_TASK_CONFIG)
         return
 

--- a/docs/entities/sensors.rst
+++ b/docs/entities/sensors.rst
@@ -106,6 +106,9 @@ Sensors that are added on integration startup.
   * - Spool ID
     - Active Spoolman spool id used for tracking/reporting. Only available when Spoolman is configured. Can be empty when tracking is disabled.
     - From Moonraker API (server.spoolman.status, spool_id)
+  * - Extruder Filament Info
+    - Additional Filament Info (Color, Type, Vendor etc.) for all four extruder. Only available on Snapmaker U1.
+    - From Moonraker API (printer.objects.query, print_task_config)
 
 
 History Sensors

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1212,6 +1212,7 @@ async def test_spoolman_spool_id_sensor_not_created_when_spool_id_missing(
     )
     assert spool_entry is None
 
+
 async def test_spoolman_spool_id_sensor_null_value(hass, get_default_api_response):
     """Do not create Spool ID sensor when Moonraker reports a spoolman error."""
     spoolman_status = {
@@ -1247,6 +1248,91 @@ async def test_spoolman_spool_id_sensor_null_value(hass, get_default_api_respons
     assert state is not None
     # When native_value is None, HA state shows as "unknown"
     assert state.state == "unknown"
+
+
+async def test_u1_filament_sensor_created(hass, get_default_api_response):
+    """Create u1 filament sensor for the u1 print_task_config result."""
+    filament_vendor = [
+        "Vendor1",
+        "Vendor2",
+        "Vendor3",
+        "Vendor4",
+    ]
+    filament_type = [
+        "Vendor1",
+        "Vendor2",
+        "Vendor3",
+        "Vendor4",
+    ]
+    filament_sub_type = [
+        "SubType1",
+        "SubType2",
+        "SubType3",
+        "SubType4",
+    ]
+    filament_color_rgba = [
+        "E2DEDBFF",
+        "E72F1DFF",
+        "F4C032FF",
+        "080A0DFF",
+    ]
+    filament_official = [True, False, True, False]
+    filament_sku = [900000, 900002, 900003, 900001]
+    filament_edit = [True, False, True, False]
+    filament_soft = [False, True, False, True]
+    u1_print_task_config_result = {
+        "status": {
+            "print_task_config": {
+                "filament_vendor": filament_vendor,
+                "filament_type": filament_type,
+                "filament_sub_type": filament_sub_type,
+                "filament_color_rgba": filament_color_rgba,
+                "filament_official": filament_official,
+                "filament_sku": filament_sku,
+                "filament_edit": filament_edit,
+                "filament_soft": filament_soft,
+            }
+        }
+    }
+
+    def _call_method_side_effect(method, *args, **kwargs):
+        if method == "printer.objects.query" and "print_task_config" in kwargs.get(
+            "objects", {}
+        ):
+            return u1_print_task_config_result
+        return {**get_default_api_response}
+
+    with patch(
+        "moonraker_api.MoonrakerClient.call_method",
+        side_effect=_call_method_side_effect,
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entity_registry = get_entity_registry(hass)
+    entries = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
+
+    for index in range(0, 3):
+        extruder = next(
+            (
+                e
+                for e in entries
+                if e.unique_id == f"{config_entry.entry_id}_e{index}_filament_info"
+            ),
+            None,
+        )
+        assert extruder is not None
+        state = hass.states.get(extruder.entity_id)
+        assert state is not None
+        assert state.state == f"#{filament_color_rgba[index]}"
+        assert state.attributes.get("type") == filament_type[index]
+        assert state.attributes.get("sku") == filament_sku[index]
+        assert state.attributes.get("vendor") == filament_vendor[index]
+        assert state.attributes.get("edit") == filament_edit[index]
+        assert state.attributes.get("official") == filament_official[index]
+        assert state.attributes.get("soft") == filament_soft[index]
 
 
 async def test_hall_filament_width_sensor_diameter_and_raw_created(


### PR DESCRIPTION
This PR adds four extruder filament information sensors specific to the Snapmaker U1.  Using the moonraker api to query for  `print_task_config` via `printer.objects.query` (see API response below)

I mapped the filament color info as a new sensor state value  (rgba hex string, prefixed with an `#`) and added the other bits (vendor, type, sku, etc.) as extra state attributes:

<img width="415" height="307" alt="Screenshot of the Extruder 0 filament info sensor visible in the developer tools in homeassistant" src="https://github.com/user-attachments/assets/3a47bbc5-541d-4d91-802d-4dac280ff847" />

And my printer dashboard using this information
<img width="265" height="333" alt="image" src="https://github.com/user-attachments/assets/27934f58-617a-4ab1-8aae-dd87c4a56737" />


<details>
<summary>Sample API Response</summary>
<pre><code>{
  "result": {
    "eventtime": 22566.172050677,
    "status": {
      "print_task_config": {
        "filament_vendor": [
          "Snapmaker",
          "Snapmaker",
          "Snapmaker",
          "Snapmaker"
        ],
        "filament_type": [
          "PLA",
          "PLA",
          "PLA",
          "PLA"
        ],
        "filament_sub_type": [
          "SnapSpeed",
          "SnapSpeed",
          "SnapSpeed",
          "SnapSpeed"
        ],
        "filament_color": [4293058267, 4293340957, 4294230066, 4278716941],
        "filament_color_rgba": [
          "E2DEDBFF",
          "E72F1DFF",
          "F4C032FF",
          "080A0DFF"
        ],
        "filament_official": [true, true, true, true],
        "filament_sku": [900000, 900002, 900003, 900001],
        "filament_edit": [false, false, false, false],
        "filament_exist": [true, true, true, true],
        "filament_soft": [false, false, false, false],
        "extruder_map_table": [0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
        "extruders_used": [false, false, false, false],
        "extruders_replenished": [0, 1, 2, 3],
        "time_lapse_camera": false,
        "auto_bed_leveling": false,
        "flow_calibrate": false,
        "shaper_calibrate": false,
        "auto_replenish_filament": true,
        "filament_entangle_detect": false,
        "reprint_info": {
          "auto_bed_leveling": false,
          "flow_calibrate": false,
          "flow_calib_extruders": [true, true, true, true],
          "time_lapse_camera": false,
          "extruder_map_table": [0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
          "extruders_used": [true, true, true, true]
        },
        "flow_calib_extruders": [true, true, true, true],
        "filament_entangle_sen": "medium"
      }
    }
  }
}</code></pre>
</details>
 