### PR TITLE
Allow offline printers, skip error messages

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -9,7 +9,7 @@ In the container you will have a dedicated Home Assistant core instance running 
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - Docker
   - For Linux, macOS, or Windows 10 Pro/Enterprise/Education use the [current release version of Docker](https://docs.docker.com/install/)
-  - Windows 10 Home requires [WSL 2](https://docs.docker.com/desktop/setup/install/windows-install/) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)). This can also be used for Windows Pro/Enterprise/Education.
+  - Windows 10 Home requires [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/desktop/setup/install/windows-install/)). This can also be used for Windows Pro/Enterprise/Education.
 - [Visual Studio code](https://code.visualstudio.com/)
 - [Remote - Containers (VSC Extension)][extension-link]
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -9,7 +9,7 @@ In the container you will have a dedicated Home Assistant core instance running 
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
 - Docker
   - For Linux, macOS, or Windows 10 Pro/Enterprise/Education use the [current release version of Docker](https://docs.docker.com/install/)
-  - Windows 10 Home requires [WSL 2](https://docs.microsoft.com/windows/wsl/wsl2-install) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)). This can also be used for Windows Pro/Enterprise/Education.
+  - Windows 10 Home requires [WSL 2](https://docs.docker.com/desktop/setup/install/windows-install/) and the current Edge version of Docker Desktop (see instructions [here](https://docs.docker.com/docker-for-windows/wsl-tech-preview/)). This can also be used for Windows Pro/Enterprise/Education.
 - [Visual Studio code](https://code.visualstudio.com/)
 - [Remote - Containers (VSC Extension)][extension-link]
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![codecov](https://codecov.io/github/marcolivierarsenault/moonraker-home-assistant/branch/main/graph/badge.svg?token=OT5PZG1QZE)](https://codecov.io/github/marcolivierarsenault/moonraker-home-assistant)
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/custom-components/hacs)
+[![codecov](https://codecov.io/github/marcolivierarsenault/moonraker-home-assistant/branch/main/graph/badge.svg?token=OT5PZG1QZE)](https://app.codecov.io/github/marcolivierarsenault/moonraker-home-assistant)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/hacs/integration)
 ![install_badge](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.moonraker.total)
 
 ## Currently unmaintained, if you are insterested to help maintain this, email me marcolivier.arsenault@gmail.com

--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -71,7 +71,7 @@ def _entry_port(entry: ConfigEntry) -> int:
     return _normalize_moonraker_port(entry.data.get(CONF_PORT, DEFAULT_PORT))
 
 
-+async def _async_is_tcp_reachable(host: str, port: int | str | None) -> bool:
+async def _async_is_tcp_reachable(host: str, port: int | str | None) -> bool:
     """Return whether a TCP connection to the Moonraker endpoint can be opened."""
     writer: asyncio.StreamWriter | None = None
     try:

--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_OPTION_QUIET_UNREACHABLE,
     CONF_TLS,
     CONF_URL,
+    DEFAULT_PORT,
     DOMAIN,
     HOSTNAME,
     METHODS,
@@ -58,14 +59,28 @@ def _log_unreachable(entry: ConfigEntry, message: str, *args: Any) -> None:
         _LOGGER.warning(message, *args)
 
 
-async def _async_is_tcp_reachable(host: str, port: int | str) -> bool:
+def _normalize_moonraker_port(port: int | str | None) -> int:
+    """Return the effective Moonraker port used at runtime."""
+    if port is None or port == "":
+        return DEFAULT_PORT
+    return int(port)
+
+
+def _entry_port(entry: ConfigEntry) -> int:
+    """Return the effective Moonraker port for a config entry."""
+    return _normalize_moonraker_port(entry.data.get(CONF_PORT, DEFAULT_PORT))
+
+
++async def _async_is_tcp_reachable(host: str, port: int | str | None) -> bool:
     """Return whether a TCP connection to the Moonraker endpoint can be opened."""
     writer: asyncio.StreamWriter | None = None
     try:
         async with async_timeout.timeout(TIMEOUT):
-            _reader, writer = await asyncio.open_connection(host, int(port))
+            _reader, writer = await asyncio.open_connection(
+                host, _normalize_moonraker_port(port)
+            )
         return True
-    except (asyncio.TimeoutError, OSError, ValueError):
+    except (asyncio.TimeoutError, OSError, TypeError, ValueError):
         return False
     finally:
         if writer is not None:
@@ -184,7 +199,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     custom_name = get_user_name(hass, entry)
 
     url = entry.data.get(CONF_URL)
-    port = entry.data.get(CONF_PORT, 7125)
+    port = _entry_port(entry)
     tls = entry.data.get(CONF_TLS, False)
     api_key = entry.data.get(CONF_API_KEY, "")
     printer_name = (
@@ -488,13 +503,13 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
         if not self.moonraker.client.is_connected:
             if not await _async_is_tcp_reachable(
                 self.config_entry.data.get(CONF_URL),
-                self.config_entry.data.get(CONF_PORT, 7125),
+                _entry_port(self.config_entry),
             ):
                 _log_unreachable(
                     self.config_entry,
                     "connection to moonraker down; %s:%s is unreachable",
                     self.config_entry.data.get(CONF_URL),
-                    self.config_entry.data.get(CONF_PORT, 7125),
+                    _entry_port(self.config_entry),
                 )
                 raise UpdateFailed()
             _LOGGER.warning("connection to moonraker down, restarting")
@@ -516,13 +531,13 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
         if not self.moonraker.client.is_connected:
             if not await _async_is_tcp_reachable(
                 self.config_entry.data.get(CONF_URL),
-                self.config_entry.data.get(CONF_PORT, 7125),
+                _entry_port(self.config_entry),
             ):
                 _log_unreachable(
                     self.config_entry,
                     "connection to moonraker down; %s:%s is unreachable",
                     self.config_entry.data.get(CONF_URL),
-                    self.config_entry.data.get(CONF_PORT, 7125),
+                    _entry_port(self.config_entry),
                 )
                 raise UpdateFailed()
             _LOGGER.warning("connection to moonraker down, restarting")

--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from contextlib import suppress
 import os.path
 import uuid
 from datetime import timedelta
@@ -22,6 +23,7 @@ from .const import (
     CONF_PORT,
     CONF_PRINTER_NAME,
     CONF_OPTION_POLLING_RATE,
+    CONF_OPTION_QUIET_UNREACHABLE,
     CONF_TLS,
     CONF_URL,
     DOMAIN,
@@ -41,6 +43,35 @@ _LOGGER = logging.getLogger(__name__)
 _LOGGER.debug("loading moonraker init")
 
 _GCODE_ROOT = "gcodes"
+
+
+def _quiet_unreachable_logs(entry: ConfigEntry) -> bool:
+    """Return whether unreachable Moonraker connection logs should be debug-only."""
+    return entry.options.get(CONF_OPTION_QUIET_UNREACHABLE, False)
+
+
+def _log_unreachable(entry: ConfigEntry, message: str, *args: Any) -> None:
+    """Log unreachable-device messages at the configured verbosity."""
+    if _quiet_unreachable_logs(entry):
+        _LOGGER.debug(message, *args)
+    else:
+        _LOGGER.warning(message, *args)
+
+
+async def _async_is_tcp_reachable(host: str, port: int | str) -> bool:
+    """Return whether a TCP connection to the Moonraker endpoint can be opened."""
+    writer: asyncio.StreamWriter | None = None
+    try:
+        async with async_timeout.timeout(TIMEOUT):
+            _reader, writer = await asyncio.open_connection(host, int(port))
+        return True
+    except (asyncio.TimeoutError, OSError, ValueError):
+        return False
+    finally:
+        if writer is not None:
+            writer.close()
+            with suppress(OSError):
+                await writer.wait_closed()
 
 
 async def async_setup(_hass: HomeAssistant, _config: ConfigType):
@@ -171,6 +202,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     try:
+        if not await _async_is_tcp_reachable(url, port):
+            _log_unreachable(
+                entry,
+                "Cannot configure moonraker instance: %s:%s is unreachable",
+                url,
+                port,
+            )
+            raise ConfigEntryNotReady(f"Error connecting to {url}:{port}")
+
         async with async_timeout.timeout(TIMEOUT):
             await api.start()
             printer_info = await api.client.call_method("printer.info")
@@ -183,8 +223,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
             hass.config_entries.async_update_entry(entry, title=api_device_name)
 
+    except ConfigEntryNotReady:
+        await api.stop()
+        raise
     except Exception as exc:
-        _LOGGER.warning("Cannot configure moonraker instance")
+        _log_unreachable(entry, "Cannot configure moonraker instance")
         await api.stop()
         raise ConfigEntryNotReady(f"Error connecting to {url}:{port}") from exc
 
@@ -443,7 +486,20 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug(f"fetching data, uuid: {myuuid}, from: {query_path.value}")
         _LOGGER.debug(f"fetching, uuid: {myuuid}, object: {query_object}")
         if not self.moonraker.client.is_connected:
-            _LOGGER.warning("connection to moonraker down, restarting")
+            if not await _async_is_tcp_reachable(
+                self.config_entry.data.get(CONF_URL),
+                self.config_entry.data.get(CONF_PORT, 7125),
+            ):
+                _log_unreachable(
+                    self.config_entry,
+                    "connection to moonraker down; %s:%s is unreachable",
+                    self.config_entry.data.get(CONF_URL),
+                    self.config_entry.data.get(CONF_PORT, 7125),
+                )
+                raise UpdateFailed()
+            _log_unreachable(
+                self.config_entry, "connection to moonraker down, restarting"
+            )
             await self.moonraker.start()
         try:
             if query_object is None:
@@ -460,7 +516,20 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_send_data(self, query_path: METHODS, query_obj) -> None:
         if not self.moonraker.client.is_connected:
-            _LOGGER.warning("connection to moonraker down, restarting")
+            if not await _async_is_tcp_reachable(
+                self.config_entry.data.get(CONF_URL),
+                self.config_entry.data.get(CONF_PORT, 7125),
+            ):
+                _log_unreachable(
+                    self.config_entry,
+                    "connection to moonraker down; %s:%s is unreachable",
+                    self.config_entry.data.get(CONF_URL),
+                    self.config_entry.data.get(CONF_PORT, 7125),
+                )
+                raise UpdateFailed()
+            _log_unreachable(
+                self.config_entry, "connection to moonraker down, restarting"
+            )
             await self.moonraker.start()
         try:
             if query_obj is None:

--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -227,7 +227,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         await api.stop()
         raise
     except Exception as exc:
-        _log_unreachable(entry, "Cannot configure moonraker instance")
+        _LOGGER.warning("Cannot configure moonraker instance")
         await api.stop()
         raise ConfigEntryNotReady(f"Error connecting to {url}:{port}") from exc
 
@@ -497,9 +497,7 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
                     self.config_entry.data.get(CONF_PORT, 7125),
                 )
                 raise UpdateFailed()
-            _log_unreachable(
-                self.config_entry, "connection to moonraker down, restarting"
-            )
+            _LOGGER.warning("connection to moonraker down, restarting")
             await self.moonraker.start()
         try:
             if query_object is None:
@@ -527,9 +525,7 @@ class MoonrakerDataUpdateCoordinator(DataUpdateCoordinator):
                     self.config_entry.data.get(CONF_PORT, 7125),
                 )
                 raise UpdateFailed()
-            _log_unreachable(
-                self.config_entry, "connection to moonraker down, restarting"
-            )
+            _LOGGER.warning("connection to moonraker down, restarting")
             await self.moonraker.start()
         try:
             if query_obj is None:

--- a/custom_components/moonraker/config_flow.py
+++ b/custom_components/moonraker/config_flow.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_PRINTER_NAME,
     CONF_TLS,
     CONF_URL,
+    DEFAULT_PORT,
     CONF_OPTION_POLLING_RATE,
     CONF_OPTION_QUIET_UNREACHABLE,
     CONF_OPTION_CAMERA_STREAM,
@@ -128,10 +129,11 @@ class MoonrakerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return True
 
     async def _test_connection(self, host, port, api_key, tls):
+        effective_port = DEFAULT_PORT if port == "" else port
         api = MoonrakerApiClient(
             host,
             async_get_clientsession(self.hass, verify_ssl=False),
-            port=port,
+            port=effective_port,
             api_key=api_key,
             tls=tls,
         )

--- a/custom_components/moonraker/config_flow.py
+++ b/custom_components/moonraker/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_TLS,
     CONF_URL,
     CONF_OPTION_POLLING_RATE,
+    CONF_OPTION_QUIET_UNREACHABLE,
     CONF_OPTION_CAMERA_STREAM,
     CONF_OPTION_CAMERA_SNAPSHOT,
     CONF_OPTION_CAMERA_PORT,
@@ -170,6 +171,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                             CONF_OPTION_POLLING_RATE, 30
                         ),
                     ): int,
+                    vol.Optional(
+                        CONF_OPTION_QUIET_UNREACHABLE,
+                        default=self.config_entry.options.get(
+                            CONF_OPTION_QUIET_UNREACHABLE, False
+                        ),
+                    ): bool,
                     vol.Optional(
                         CONF_OPTION_CAMERA_STREAM,
                         default=self.config_entry.options.get(

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -29,6 +29,7 @@ CONF_PRINTER_NAME = "printer_name"
 CONF_OPTION_CAMERA_STREAM = "camera_stream_url"
 CONF_OPTION_CAMERA_SNAPSHOT = "camera_snapshot_url"
 CONF_OPTION_POLLING_RATE = "polling_rate"
+CONF_OPTION_QUIET_UNREACHABLE = "quiet_unreachable_devices"
 CONF_OPTION_CAMERA_PORT = "camera_port"
 CONF_OPTION_THUMBNAIL_PORT = "thumbnail_port"
 

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -40,6 +40,9 @@ OBJ = "objects"
 # API timeout
 TIMEOUT = 10
 
+# CONNECTION DATA
+DEFAULT_PORT = 7125
+
 
 class METHODS(Enum):
     """API methods."""

--- a/custom_components/moonraker/translations/en.json
+++ b/custom_components/moonraker/translations/en.json
@@ -25,6 +25,7 @@
       "init": {
         "data": {
           "polling_rate": "Integration polling rate (s)",
+          "quiet_unreachable_devices": "Log unreachable printer connection messages only at DEBUG level",
           "camera_stream_url": "Camera Stream URL",
           "camera_snapshot_url": "Camera Snapshot URL",
           "camera_port": "Camera Port",

--- a/custom_components/moonraker/translations/es.json
+++ b/custom_components/moonraker/translations/es.json
@@ -25,6 +25,7 @@
       "init": {
         "data": {
           "polling_rate": "Tasa de sondeo de la integración (s)",
+          "quiet_unreachable_devices": "Registrar los mensajes de conexión de impresora inalcanzable solo en nivel DEBUG",
           "camera_stream_url": "URL de la transmisión de la cámara",
           "camera_snapshot_url": "URL de la instantánea de la cámara",
           "camera_port": "Puerto de la cámara",

--- a/docs/connection.rst
+++ b/docs/connection.rst
@@ -55,17 +55,13 @@ Camera URL can be manually defined more details in the :ref:`camera_config`
 Unreachable Printer
 -------------------------------------
 
-If you have your printer turned off by a smart switch or the printer is not reachable, the integration will try to connect to the printer every 30 seconds.
-This is not problematic for the Home Assistant setup, but it may cause some redundent logs in the Home Assistant log file.
+If you have your printer turned off by a smart switch or the printer is not reachable, the integration will periodically try to reconnect.
+This is not problematic for Home Assistant, but it may create repetitive connection messages in the Home Assistant log file.
 
-To avoid this, you can add a filter to the logger configuration in the Home Assistant configuration file.
-
-.. code-block:: yaml
-
-  logger:
-    filters:
-      moonraker_api.websockets.websocketclient:
-        - ".*Websocket connection error: Cannot connect to host*"
+In the integration options for the affected printer, enable
+``Log unreachable printer connection messages only at DEBUG level``.
+When enabled, the integration first checks whether the Moonraker host and port are reachable and avoids starting the websocket client while the endpoint is offline.
+This suppresses the normal warning/error noise for intentionally powered-off printers, while DEBUG logging still retains diagnostic information.
 
 Change IP/Hostname of your printer
 -------------------------------------

--- a/info.md
+++ b/info.md
@@ -48,5 +48,5 @@ This allows you home assistant to connect to your Klipper 3D printer and display
 [hacsbadge]: https://img.shields.io/badge/HACS-Custom-orange.svg?style=for-the-badge
 [license]: https://github.com/marcolivierarsenault/moonraker-home-assistant/blob/main/LICENSE
 [license-shield]: https://img.shields.io/github/license/marcolivierarsenault/moonraker-home-assistant.svg?style=for-the-badge
-[releases-shield]: https://img.shields.io/github/release/marcolivierarsenault/moonraker-home-assistant.svg?style=for-the-badge
+[releases-shield]: https://img.shields.io/github/v/release/marcolivierarsenault/moonraker-home-assistant.svg?style=for-the-badge
 [releases]: https://github.com/marcolivierarsenault/moonraker-home-assistant/releases

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 """Global fixtures for integration_blueprint integration."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -36,6 +36,23 @@ def skip_notifications_fixture():
     with (
         patch("homeassistant.components.persistent_notification.async_create"),
         patch("homeassistant.components.persistent_notification.async_dismiss"),
+    ):
+        yield
+
+
+@pytest.fixture(name="bypass_tcp_reachable", autouse=True)
+def bypass_tcp_reachable_fixture():
+    """Treat the Moonraker endpoint as reachable during tests.
+
+    The integration probes the printer with a real TCP connection before
+    configuring the entry. Tests use a mocked API client, so default to a
+    reachable endpoint; individual tests can patch this to exercise the
+    offline path.
+    """
+    with patch(
+        "custom_components.moonraker._async_is_tcp_reachable",
+        new_callable=AsyncMock,
+        return_value=True,
     ):
         yield
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -25,7 +25,12 @@ from custom_components.moonraker import (
     async_setup_entry,
     async_unload_entry,
 )
-from custom_components.moonraker.const import DOMAIN, METHODS, OBJ
+from custom_components.moonraker.const import (
+    CONF_OPTION_QUIET_UNREACHABLE,
+    DOMAIN,
+    METHODS,
+    OBJ,
+)
 
 from .const import MOCK_CONFIG, MOCK_CONFIG_WITH_NAME
 
@@ -33,7 +38,14 @@ from .const import MOCK_CONFIG, MOCK_CONFIG_WITH_NAME
 @pytest.fixture(name="bypass_connect_client", autouse=True)
 def bypass_connect_client_fixture():
     """Skip calls to get data from API."""
-    with patch("custom_components.moonraker.MoonrakerApiClient.start"):
++    with (
+        patch("custom_components.moonraker.MoonrakerApiClient.start"),
+        patch(
+            "custom_components.moonraker._async_is_tcp_reachable",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+    ):
         yield
 
 
@@ -331,6 +343,64 @@ async def test_setup_entry_exception(hass):
 
         with pytest.raises(ConfigEntryNotReady):
             assert await async_setup_entry(hass, config_entry)
+
+
+async def test_setup_entry_unreachable_logs_warning_by_default(hass, caplog):
+    """Unreachable printers keep warning-level visibility unless silenced."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="offline")
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.moonraker._async_is_tcp_reachable",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        caplog.at_level(logging.DEBUG),
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, config_entry)
+
+    assert "Cannot configure moonraker instance" in caplog.text
+    assert any(
+        record.levelno == logging.WARNING
+        and "Cannot configure moonraker instance" in record.message
+        for record in caplog.records
+    )
+
+
+async def test_setup_entry_unreachable_logs_debug_when_option_enabled(hass, caplog):
+    """Unreachable printers can be configured to avoid warning-level log spam."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        options={CONF_OPTION_QUIET_UNREACHABLE: True},
+        entry_id="offline_quiet",
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.moonraker._async_is_tcp_reachable",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        caplog.at_level(logging.DEBUG),
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, config_entry)
+
+    assert "Cannot configure moonraker instance" in caplog.text
+    assert any(
+        record.levelno == logging.DEBUG
+        and "Cannot configure moonraker instance" in record.message
+        for record in caplog.records
+    )
+    assert not any(
+        record.levelno >= logging.WARNING
+        and "Cannot configure moonraker instance" in record.message
+        for record in caplog.records
+    )
 
 
 async def test_coordinator_passes_config_entry_to_super(hass):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -345,6 +345,34 @@ async def test_setup_entry_exception(hass):
             assert await async_setup_entry(hass, config_entry)
 
 
+async def test_setup_entry_generic_exception_stays_warning_when_option_enabled(hass, caplog):
+    """Quiet unreachable mode must not hide non-reachability setup failures."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        options={CONF_OPTION_QUIET_UNREACHABLE: True},
+        entry_id="setup_error_quiet",
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "moonraker_api.MoonrakerClient.call_method",
+            new_callable=AsyncMock,
+            side_effect=Exception,
+        ),
+        caplog.at_level(logging.DEBUG),
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, config_entry)
+
+    assert any(
+        record.levelno == logging.WARNING
+        and record.message == "Cannot configure moonraker instance"
+        for record in caplog.records
+    )
+
+
 async def test_setup_entry_unreachable_logs_warning_by_default(hass, caplog):
     """Unreachable printers keep warning-level visibility unless silenced."""
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="offline")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,6 +18,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.moonraker import (
     MoonrakerDataUpdateCoordinator,
+    _async_is_tcp_reachable,
     _build_thumbnail_path,
     _normalize_gcode_path,
     _normalize_moonraker_port,
@@ -360,7 +361,9 @@ async def test_setup_entry_exception(hass):
             assert await async_setup_entry(hass, config_entry)
 
 
-async def test_setup_entry_generic_exception_stays_warning_when_option_enabled(hass, caplog):
+async def test_setup_entry_generic_exception_stays_warning_when_option_enabled(
+    hass, caplog
+):
     """Quiet unreachable mode must not hide non-reachability setup failures."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -463,6 +466,72 @@ async def test_setup_entry_unreachable_logs_debug_when_option_enabled(hass, capl
         and "Cannot configure moonraker instance" in record.message
         for record in caplog.records
     )
+
+
+async def test_async_is_tcp_reachable_returns_true_when_connection_opens():
+    """A successful TCP connection marks the endpoint as reachable."""
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+
+    with patch(
+        "custom_components.moonraker.asyncio.open_connection",
+        new_callable=AsyncMock,
+        return_value=(MagicMock(), writer),
+    ):
+        assert await _async_is_tcp_reachable("1.2.3.4", 7125) is True
+
+    writer.close.assert_called_once()
+    writer.wait_closed.assert_awaited_once()
+
+
+async def test_async_is_tcp_reachable_returns_false_when_connection_fails():
+    """Connection errors mark the endpoint as unreachable."""
+    with patch(
+        "custom_components.moonraker.asyncio.open_connection",
+        new_callable=AsyncMock,
+        side_effect=OSError,
+    ):
+        assert await _async_is_tcp_reachable("1.2.3.4", 7125) is False
+
+
+async def test_async_fetch_data_unreachable_raises_update_failed(hass):
+    """Fetching while disconnected and unreachable raises UpdateFailed."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    with (
+        patch(
+            "custom_components.moonraker._async_is_tcp_reachable",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator.async_fetch_data(METHODS.PRINTER_INFO)
+
+    assert await async_unload_entry(hass, config_entry)
+
+
+async def test_async_send_data_unreachable_raises_update_failed(hass):
+    """Sending while disconnected and unreachable raises UpdateFailed."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    with (
+        patch(
+            "custom_components.moonraker._async_is_tcp_reachable",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coordinator.async_send_data(METHODS.PRINTER_EMERGENCY_STOP)
+
+    assert await async_unload_entry(hass, config_entry)
 
 
 async def test_coordinator_passes_config_entry_to_super(hass):
@@ -660,9 +729,12 @@ async def test_send_gcode_identifier_fallback(hass):
             return identifier_device
         return original_async_get(device_id)
 
-    with patch.object(dev_reg, "async_get", side_effect=async_get_override), patch(
-        "moonraker_api.MoonrakerClient.call_method", new_callable=AsyncMock
-    ) as mock_call:
+    with (
+        patch.object(dev_reg, "async_get", side_effect=async_get_override),
+        patch(
+            "moonraker_api.MoonrakerClient.call_method", new_callable=AsyncMock
+        ) as mock_call,
+    ):
         await hass.services.async_call(
             DOMAIN,
             "send_gcode",
@@ -704,9 +776,12 @@ async def test_send_gcode_skips_device_without_entries(hass):
             return orphan_device
         return original_async_get(device_id)
 
-    with patch.object(dev_reg, "async_get", side_effect=async_get_override), patch(
-        "moonraker_api.MoonrakerClient.call_method", new_callable=AsyncMock
-    ) as mock_call:
+    with (
+        patch.object(dev_reg, "async_get", side_effect=async_get_override),
+        patch(
+            "moonraker_api.MoonrakerClient.call_method", new_callable=AsyncMock
+        ) as mock_call,
+    ):
         await hass.services.async_call(
             DOMAIN,
             "send_gcode",
@@ -746,9 +821,12 @@ async def test_send_gcode_skips_unloaded_entries(hass):
             return missing_device
         return original_async_get(device_id)
 
-    with patch.object(dev_reg, "async_get", side_effect=async_get_override), patch(
-        "moonraker_api.MoonrakerClient.call_method", new_callable=AsyncMock
-    ) as mock_call:
+    with (
+        patch.object(dev_reg, "async_get", side_effect=async_get_override),
+        patch(
+            "moonraker_api.MoonrakerClient.call_method", new_callable=AsyncMock
+        ) as mock_call,
+    ):
         await hass.services.async_call(
             DOMAIN,
             "send_gcode",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -38,7 +38,7 @@ from .const import MOCK_CONFIG, MOCK_CONFIG_WITH_NAME
 @pytest.fixture(name="bypass_connect_client", autouse=True)
 def bypass_connect_client_fixture():
     """Skip calls to get data from API."""
-+    with (
+    with (
         patch("custom_components.moonraker.MoonrakerApiClient.start"),
         patch(
             "custom_components.moonraker._async_is_tcp_reachable",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -20,6 +20,7 @@ from custom_components.moonraker import (
     MoonrakerDataUpdateCoordinator,
     _build_thumbnail_path,
     _normalize_gcode_path,
+    _normalize_moonraker_port,
     _strip_gcode_root,
     async_reload_entry,
     async_setup_entry,
@@ -27,6 +28,8 @@ from custom_components.moonraker import (
 )
 from custom_components.moonraker.const import (
     CONF_OPTION_QUIET_UNREACHABLE,
+    CONF_PORT,
+    DEFAULT_PORT,
     DOMAIN,
     METHODS,
     OBJ,
@@ -47,6 +50,18 @@ def bypass_connect_client_fixture():
         ),
     ):
         yield
+
+
+def test_normalize_moonraker_port_uses_default_for_empty_values():
+    """Empty configured ports should use the Moonraker default port."""
+    assert _normalize_moonraker_port("") == DEFAULT_PORT
+    assert _normalize_moonraker_port(None) == DEFAULT_PORT
+
+
+def test_normalize_moonraker_port_converts_configured_values():
+    """Configured ports should be converted to integers for socket probing."""
+    assert _normalize_moonraker_port("7611") == 7611
+    assert _normalize_moonraker_port(7611) == 7611
 
 
 def test_normalize_gcode_path_empty():
@@ -395,6 +410,25 @@ async def test_setup_entry_unreachable_logs_warning_by_default(hass, caplog):
         and "Cannot configure moonraker instance" in record.message
         for record in caplog.records
     )
+
+
+async def test_setup_entry_empty_port_uses_default_for_reachability_probe(hass):
+    """Empty stored ports remain accepted and are probed as the default port."""
+    config = {**MOCK_CONFIG, CONF_PORT: ""}
+    config_entry = MockConfigEntry(domain=DOMAIN, data=config, entry_id="empty_port")
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.moonraker._async_is_tcp_reachable",
+            new_callable=AsyncMock,
+            return_value=False,
+        ) as is_reachable,
+        pytest.raises(ConfigEntryNotReady),
+    ):
+        await async_setup_entry(hass, config_entry)
+
+    is_reachable.assert_awaited_once_with("1.2.3.4", DEFAULT_PORT)
 
 
 async def test_setup_entry_unreachable_logs_debug_when_option_enabled(hass, caplog):


### PR DESCRIPTION
The error messages about offline printers can be lowered in severity to avoid spamming the logs and without requiring any manual filtering (!!!) of the logs as previously suggested in the docs.