### PR TITLE
Consolidate dependency, workflow, and Python version bumps

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "moonraker-home-assistant",
-  "image": "mcr.microsoft.com/devcontainers/python:dev-3.13-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/python:dev-3.14-bookworm",
   "mounts": [
     "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
   ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: "actions/checkout@v7"
 
       - name: HACS validation
         uses: "hacs/action@main"
@@ -30,7 +30,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Checkout the repository"
-        uses: "actions/checkout@v6"
+        uses: "actions/checkout@v7"
 
       - name: "Set up Python"
         uses: actions/setup-python@v6
@@ -51,7 +51,7 @@ jobs:
       contents: write
     steps:
       - name: Check out code from GitHub
-        uses: "actions/checkout@v6"
+        uses: "actions/checkout@v7"
       - name: Setup Python
         uses: "actions/setup-python@v6"
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,6 @@ jobs:
         run: |
           pytest . --cov=custom_components.moonraker --cov-report=xml
       - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: "Set up Python"
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
 
       - name: "Install requirements"
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Python
         uses: "actions/setup-python@v6"
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install requirements
         run: python3 -m pip install -r requirements.txt
       - name: Run tests

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: "actions/checkout@v7"
 
       - name: HACS validation
         uses: "hacs/action@main"

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -22,7 +22,7 @@ jobs:
     name: Check links in all Markdown files
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Check links in all Markdown files
         uses: lycheeverse/lychee-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py39-plus]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Core integration code sits in `custom_components/moonraker/`: Home Assistant boo
 
 ## Coding Style & Naming Conventions
 
-Target Python 3.13 with four-space indentation. Follow Home Assistant norms: modules and entities in snake_case, user-facing strings sentence case, constants upper snake in `const.py`, and translation keys lower_snake_case. Let Ruff enforce formatting and import sorting (`scripts/lint` or `ruff format`). Keep docstrings concise and update type hints when behaviour shifts.
+Target Python 3.14 with four-space indentation. Follow Home Assistant norms: modules and entities in snake_case, user-facing strings sentence case, constants upper snake in `const.py`, and translation keys lower_snake_case. Let Ruff enforce formatting and import sorting (`scripts/lint` or `ruff format`). Keep docstrings concise and update type hints when behaviour shifts.
 
 ## Testing Guidelines
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==9.1.0
 furo==2025.12.19
-sphinx-toolbox==4.1.2
+sphinx-toolbox==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pytest-homeassistant-custom-component==0.13.316
 moonraker-api==2.0.6
-pre-commit==4.5.1
+pre-commit==4.6.0
 sphinx==9.1.0
 colorlog==6.10.1
 furo==2025.12.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ furo==2025.12.19
 ruff==0.15.9
 ha-ffmpeg==3.2.2
 pyspeex-noise==2.0.0
-sphinx-toolbox==4.1.2
+sphinx-toolbox==4.2.0
 bump2version==1.0.1
 PyTurboJPEG==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ colorlog==6.10.1
 furo==2025.12.19
 ruff==0.15.9
 ha-ffmpeg==3.2.2
-pyspeex-noise==2.0.0
+pyspeex-noise==2.0.1
 sphinx-toolbox==4.2.0
 bump2version==1.0.1
 PyTurboJPEG==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pytest-homeassistant-custom-component==0.13.316
+pytest-homeassistant-custom-component==0.13.337
 moonraker-api==2.0.6
 pre-commit==4.6.0
 sphinx==9.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pre-commit==4.6.0
 sphinx==9.1.0
 colorlog==6.10.1
 furo==2025.12.19
-ruff==0.15.9
+ruff==0.15.16
 ha-ffmpeg==3.2.2
 pyspeex-noise==2.0.1
 sphinx-toolbox==4.2.0

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -174,8 +174,10 @@ async def test_thumbnail_camera_image(
     await camera.async_get_image(hass, "camera.mainsail_thumbnail")
 
 
-async def test_thumbnail_camera_from_img_to_none(hass):
+async def test_thumbnail_camera_from_img_to_none(hass, aioclient_mock):
     """Test thumbnail camera from img to none."""
+
+    del aioclient_mock
 
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
     config_entry.add_to_hass(hass)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -31,8 +31,11 @@ def bypass_connect_client_fixture():
 @pytest.fixture(name="error_connect_client")
 def error_connect_client_fixture():
     """Throw error when trying to connect."""
-    with patch("custom_components.moonraker.MoonrakerApiClient.start"):
-        raise Exception
+    with patch(
+        "custom_components.moonraker.MoonrakerApiClient.start",
+        side_effect=Exception,
+    ):
+        yield
 
 
 @pytest.mark.usefixtures("bypass_connect_client")
@@ -384,6 +387,7 @@ async def test_printer_name_when_good(hass):
     assert result["result"]
 
 
+@pytest.mark.usefixtures("error_connect_client")
 async def test_bad_connection_config_flow(hass):
     """Test a config flow with a bad connection."""
     # Initialize a config flow


### PR DESCRIPTION
## Summary

Consolidates the open dependency and GitHub Actions version bumps into one pull request:

- #731 — pre-commit 4.5.1 → 4.6.0
- #742 — sphinx-toolbox 4.1.2 → 4.2.0
- #748 — codecov/codecov-action 6 → 7
- #749 — pyspeex-noise 2.0.0 → 2.0.1
- #750 — Ruff 0.15.9 → 0.15.16
- #751 — pytest-homeassistant-custom-component 0.13.316 → 0.13.337
- #752 — actions/checkout 5/6 → 7

The original Dependabot commits and authorship are preserved.

## Python 3.14 compatibility

PR #751 follows current Home Assistant releases onto Python 3.14. This PR therefore also:

- bumps CI from Python 3.13 to 3.14
- bumps the devcontainer image from Python 3.13 to 3.14
- updates the repository guidance to Python 3.14
- bumps pyupgrade 3.3.1 → 3.21.2 because the old hook uses AST APIs removed in Python 3.14
- updates two tests to mock their expected failed network calls, as required by the stricter test plugin

No feature or integration-behavior PRs are included.

## Impact

Development, CI, and tests now use Python 3.14 and the newer Home Assistant custom-component test stack. Runtime integration behavior is unchanged.

## Validation

Run with CPython 3.14.2:

- `scripts/setup`
- `scripts/test_strict` — 230 passed, 100% coverage
- changed-file pre-commit suite — pyupgrade, Ruff, Ruff format, Prettier, and Lychee passed
- `scripts/docs_build` — passed with warnings treated as errors

Note: running pre-commit against every file identifies pre-existing formatting changes in README.md and the Spanish translation. Those unrelated changes were restored and are not included here.