### PR TITLE
Support Rinkhals printer names

### DIFF
--- a/custom_components/moonraker/__init__.py
+++ b/custom_components/moonraker/__init__.py
@@ -27,6 +27,7 @@ from .const import (
     CONF_TLS,
     CONF_URL,
     DEFAULT_PORT,
+    DEVICE_TYPE,
     DOMAIN,
     HOSTNAME,
     METHODS,
@@ -231,10 +232,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             printer_info = await api.client.call_method("printer.info")
             _LOGGER.debug(printer_info)
 
-            if printer_name == "" or printer_name is None:
-                api_device_name = printer_info[HOSTNAME]
-            else:
-                api_device_name = printer_name
+            api_device_name = (
+                printer_name
+                or printer_info.get(HOSTNAME)
+                or printer_info.get(DEVICE_TYPE)
+                or url
+            )
 
             hass.config_entries.async_update_entry(entry, title=api_device_name)
 

--- a/custom_components/moonraker/const.py
+++ b/custom_components/moonraker/const.py
@@ -34,6 +34,7 @@ CONF_OPTION_CAMERA_PORT = "camera_port"
 CONF_OPTION_THUMBNAIL_PORT = "thumbnail_port"
 
 # API dict keys
+DEVICE_TYPE = "device_type"
 HOSTNAME = "hostname"
 OBJ = "objects"
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -326,6 +326,59 @@ async def test_setup_unload_and_reload_entry_with_name(hass):
     assert config_entry.entry_id not in hass.data[DOMAIN]
 
 
+@pytest.mark.parametrize(
+    ("printer_info", "expected_name"),
+    [
+        (
+            {
+                "device_type": "Anycubic Kobra 2 Pro",
+                "state": "ready",
+                "state_message": "Printer is ready",
+                "software_version": "",
+            },
+            "Anycubic Kobra 2 Pro",
+        ),
+        (
+            {
+                "state": "ready",
+                "state_message": "Printer is ready",
+                "software_version": "",
+            },
+            MOCK_CONFIG["url"],
+        ),
+    ],
+)
+async def test_setup_entry_without_hostname_uses_fallback_name(
+    hass, get_default_api_response, printer_info, expected_name
+):
+    """Use compatible names when printer.info does not include a hostname."""
+
+    async def load_data(endpoint, *args, **kwargs):
+        if endpoint == METHODS.PRINTER_INFO.value:
+            return printer_info
+
+        return get_default_api_response
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=MOCK_CONFIG,
+        entry_id=f"missing_hostname_{expected_name}",
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "moonraker_api.MoonrakerClient.call_method",
+        new_callable=AsyncMock,
+        side_effect=load_data,
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    assert config_entry.title == expected_name
+    assert coordinator.api_device_name == expected_name
+    assert await async_unload_entry(hass, config_entry)
+
+
 async def test_async_send_data_exception(hass):
     """Test async_post_exception."""
 


### PR DESCRIPTION
## Summary

- preserve configured printer names and standard Moonraker hostnames
- fall back to Rinkhals' `device_type` when `printer.info` omits `hostname`
- use the configured host as a final non-empty name
- cover both fallback paths through full Home Assistant config-entry setup tests

## Root cause

Rinkhals returns a reduced `printer.info` response without the standard `hostname` field. The integration accessed that field with a strict dictionary lookup, raising `KeyError` and converting an otherwise reachable printer into `ConfigEntryNotReady`.

This keeps standard Moonraker behavior unchanged while allowing the Rinkhals response to complete setup.

Fixes #761.

## Validation

- `pytest --durations=10 --cov-report term-missing --cov=custom_components.moonraker --cov-fail-under=100 tests` — 242 passed, 100% coverage
- focused setup regression tests — 4 passed
- `pre-commit run --files custom_components/moonraker/__init__.py custom_components/moonraker/const.py tests/test_init.py` — passed
- `git diff --check` — passed

Hardware validation against a Rinkhals printer was not available locally.