### PR TITLE
fix: handle incomplete Moonraker output pin and heater configuration (Qidi Q2)

### DIFF
--- a/custom_components/moonraker/number.py
+++ b/custom_components/moonraker/number.py
@@ -90,7 +90,11 @@ async def async_setup_temperature_target(coordinator, entry, async_add_entities)
 
         elif obj.startswith("heater_generic"):
             _, _, heater_name = obj.partition(" ")
-            display_name = heater_name.replace("_", " ").title() if heater_name else "Heater Generic"
+            display_name = (
+                heater_name.replace("_", " ").title()
+                if heater_name
+                else "Heater Generic"
+            )
 
             settings = config_settings.get(obj)
             if settings is None:
@@ -101,6 +105,12 @@ async def async_setup_temperature_target(coordinator, entry, async_add_entities)
             max_temp = settings.get("max_temp")
             min_temp = settings.get("min_temp")
 
+            # Qidi may list virtual/generic heaters in printer objects
+            # without their matching configfile settings. A HA Number
+            # entity requires a numeric max_value, so skip these safely.
+            if max_temp is None:
+                continue
+
             desc = MoonrakerNumberSensorDescription(
                 key=f"{obj.replace(' ', '_')}_target_number",
                 sensor_name=obj,
@@ -109,8 +119,11 @@ async def async_setup_temperature_target(coordinator, entry, async_add_entities)
                 subscriptions=[(obj, "target")],
                 icon="mdi:radiator",
                 unit=UnitOfTemperature.CELSIUS,
-                update_code=f"SET_HEATER_TEMPERATURE HEATER={heater_name or 'heater_generic'} TARGET=",
-                max_value=float(max_temp) if max_temp is not None else None,
+                update_code=(
+                    f"SET_HEATER_TEMPERATURE "
+                    f"HEATER={heater_name or 'heater_generic'} TARGET="
+                ),
+                max_value=float(max_temp),
                 min_value=float(min_temp) if min_temp is not None else 0.0,
                 device_class=NumberDeviceClass.TEMPERATURE,
             )
@@ -158,7 +171,7 @@ async def async_setup_temperature_target(coordinator, entry, async_add_entities)
 
 
 async def async_setup_output_pin(coordinator, entry, async_add_entities):
-    """Set optional binary sensor platform."""
+    """Set optional number platform for PWM output pins."""
 
     object_list = await coordinator.async_fetch_data(METHODS.PRINTER_OBJECTS_LIST)
 
@@ -167,12 +180,25 @@ async def async_setup_output_pin(coordinator, entry, async_add_entities):
         METHODS.PRINTER_OBJECTS_QUERY, query_obj, quiet=True
     )
 
+    config_settings = (
+        settings.get("status", {})
+        .get("configfile", {})
+        .get("settings", {})
+    )
+
     numbers = []
+
     for obj in object_list["objects"]:
         if "output_pin" not in obj:
             continue
 
-        if not settings["status"]["configfile"]["settings"][obj.lower()]["pwm"]:
+        output_pin_config = config_settings.get(obj.lower())
+
+        if not output_pin_config or not output_pin_config.get("pwm", False):
+            _LOGGER.debug(
+                "Skipping output pin '%s': no matching configfile setting or not PWM",
+                obj,
+            )
             continue
 
         desc = MoonrakerNumberSensorDescription(
@@ -189,7 +215,6 @@ async def async_setup_output_pin(coordinator, entry, async_add_entities):
     async_add_entities(
         [MoonrakerPWMOutputPin(coordinator, entry, desc) for desc in numbers]
     )
-
 
 async def async_setup_speed_factor(coordinator, entry, async_add_entities):
     """Set up speed factor number entity."""
@@ -295,7 +320,6 @@ def _coerce_float(value: Any) -> float | None:
     except (TypeError, ValueError):
         return None
 
-
 class MoonrakerPWMOutputPin(BaseMoonrakerEntity, NumberEntity):
     """Moonraker PWM output pin class."""
 
@@ -309,6 +333,9 @@ class MoonrakerPWMOutputPin(BaseMoonrakerEntity, NumberEntity):
         super().__init__(coordinator, entry)
         self.pin = description.sensor_name.replace("output_pin ", "")
         self._attr_mode = NumberMode.SLIDER
+        self._attr_native_min_value = 0.0
+        self._attr_native_max_value = 100.0
+        self._attr_native_step = 1.0
         self.entity_description: MoonrakerNumberSensorDescription = description
         self.sensor_name = description.sensor_name
         self._attr_unique_id = f"{entry.entry_id}_{description.key}"

--- a/custom_components/moonraker/switch.py
+++ b/custom_components/moonraker/switch.py
@@ -35,7 +35,7 @@ async def _power_device_updater(coordinator):
 
 
 async def async_setup_output_pin(coordinator, entry, async_add_entities):
-    """Set optional binary sensor platform."""
+    """Set optional switch platform for non-PWM output pins."""
 
     object_list = await coordinator.async_fetch_data(METHODS.PRINTER_OBJECTS_LIST)
 
@@ -44,19 +44,31 @@ async def async_setup_output_pin(coordinator, entry, async_add_entities):
         METHODS.PRINTER_OBJECTS_QUERY, query_obj, quiet=True
     )
 
+    config_settings = (
+        settings.get("status", {})
+        .get("configfile", {})
+        .get("settings", {})
+    )
+
     switches = []
+
     for obj in object_list["objects"]:
         if "output_pin" not in obj:
             continue
 
-        if settings["status"]["configfile"]["settings"][obj.lower()]["pwm"]:
+        output_pin_config = config_settings.get(obj.lower())
+
+        if not output_pin_config:
+            continue
+
+        if output_pin_config.get("pwm", False):
             continue
 
         desc = MoonrakerSwitchSensorDescription(
             key=obj,
             sensor_name=obj,
             name=obj.replace("_", " ").title(),
-            icon="mdi:switch",
+            icon="mdi:toggle-switch-outline",
             subscriptions=[(obj, "value")],
         )
         switches.append(desc)
@@ -66,7 +78,6 @@ async def async_setup_output_pin(coordinator, entry, async_add_entities):
     async_add_entities(
         [MoonrakerDigitalOutputPin(coordinator, entry, desc) for desc in switches]
     )
-
 
 async def async_setup_power_device(coordinator, entry, async_add_entities):
     """Set optional binary sensor platform."""


### PR DESCRIPTION
## Summary

On Qidi Q2 integration was missing all numbers and switches sensors because both .py files failed to load.

Fixes integration setup failures when Moonraker reports objects that do not have a corresponding entry in `configfile.settings`.

This was observed on a Qidi Q2, where Moonraker exposes `smart_output_pin polar_cooler` in the printer object list but no matching `configfile.settings` entry exists. The previous direct dictionary lookup raised a `KeyError`, preventing the entire Number and Switch platforms from loading.

## Changes

Changes are LLM assisted.

- Safely skip output-pin objects missing from `configfile.settings`
  instead of raising `KeyError`
- Keep PWM output pins in the Number platform and non-PWM pins in the
  Switch platform
- Define explicit 0–100 slider bounds for PWM output-pin Number entities
- Skip `heater_generic` target controls when `max_temp` is unavailable,
  since Home Assistant Number entities require numeric min/max values

## Result

A missing or incomplete vendor-specific object no longer prevents valid
entities from being created, including extruder and bed target
temperature controls.

## Testing

Tested with a Qidi Q2 Moonraker instance that:

- Lists `smart_output_pin polar_cooler` in `/printer/objects/list`
- Does not include that object in `configfile.settings`
- Exposes valid `extruder.target` and `heater_bed.target` values through
  `/printer/objects/query`

After the changes, the Number and Switch platforms load without errors,
valid output-pin entities are created, and extruder/bed target Number
entities become available.