### PR TITLE
Remove unmaintained repository notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-blue.svg)](https://github.com/hacs/integration)
 ![install_badge](https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https://analytics.home-assistant.io/custom_integrations.json&query=$.moonraker.total)
 
-## Currently unmaintained, if you are insterested to help maintain this, email me marcolivier.arsenault@gmail.com
-
-
 # Moonraker Home Assistant
 
 Non official integration for Moonraker and Klipper in Home Assistant (via HACS).


### PR DESCRIPTION
### Motivation
- Remove an outdated "Currently unmaintained" notice and maintainer email from the repository README so the project status/heading follows the status badges directly.

### Description
- Delete the line containing the unmaintained notice from `README.md` so the main project heading appears immediately after the badges.

### Testing
- Ran `git diff --check` which reported no issues.
- Ran `pre-commit run prettier --all-files` which passed.
- Ran `pre-commit run --all-files` where `pyupgrade`, `ruff`, `ruff-format`, and `prettier` hooks passed; the run was interrupted when the Lychee link checker stalled without producing output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a94a388c6788320afa9e5691e25c804)